### PR TITLE
feat : gym 관련 엔티티 생성

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/Gym.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/Gym.java
@@ -1,0 +1,31 @@
+package com.ll.townforest.boundedContext.gym.entity;
+
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class Gym {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@OneToOne
+	@ToString.Exclude
+	private Apt apt;
+
+	private String name;
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -39,7 +39,7 @@ public class GymHistory {
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
 	private LocalDateTime paymentDate;
-	private int amountOfPayment;
+	private int price;
 	/*
 	결제 방법
 	0 : 계좌이체
@@ -55,7 +55,7 @@ public class GymHistory {
 	private int passType;
 	/*
 	상태
-	0: 이용중
+	0: 결제
 	1: 만료
 	2: 연장	등
 	추가 예정	// TODO : 상태 고려

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -1,0 +1,64 @@
+package com.ll.townforest.boundedContext.gym.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@ToString
+public class GymHistory {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne
+	private AptAccount user;
+	@ManyToOne
+	private Gym gym;
+	@ManyToOne
+	private Apt apt;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private LocalDateTime paymentDate;
+	private int amountOfPayment;
+	/*
+	결제 방법
+	0 : 계좌이체
+	1 : 카드
+	*/
+	private int paymentMethod;
+	/*
+	이용권 종류
+	0: 30일권
+	1: 60일권
+	2: 90일권
+	*/
+	private int passType;
+	/*
+	상태
+	0: 이용중
+	1: 만료
+	2: 연장	등
+	추가 예정	// TODO : 상태 고려
+	*/
+	private int status;
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -1,0 +1,42 @@
+package com.ll.townforest.boundedContext.gym.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@ToString
+public class GymMembership {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne
+	private AptAccount user;
+	@ManyToOne
+	private Gym gym;
+	@ManyToOne
+	private Apt apt;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private LocalDateTime paymentDate;
+}


### PR DESCRIPTION
<!-- pull_request_docs.md 파일은 기본 주소 뒤에 ?template=pull_request_docs.md 를 붙여서 접속합니다. -->
<!-- 예시 : https://github.com/SoloForest/TownForest/compare/main...enhancement1/templates?template=pull_request.docs.md -->

## Description
 Gym, GymHistory, GymMemberShip 엔티티 작성

<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- [x] Gym
  - 아파트 내 헬스장 정보를 나타냅니다.
- [x] GymHistory
  - 헬스장 결제내역을 나타냅니다.
- [x] GymMemberShip
  - 현재 사용 중인 헬스장 이용권 정보를 나타냅니다(기간 만료 시 삭제 처리)

### ETC
- GymHistory에 status 2번 연장을 생각했는데, 관리자가 연장을 시켜준다던가 아니면 추가 결제 등 있을 것 같은데 조금만 더 생각해볼게요! 일단 0, 1은 확정입니다!
- 파일 경로 : boundedContext > gym> entity > Gym, GymHistory, GymMemberShip
---
Close #7 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->