### PR TITLE
Enhancement14/init data

### DIFF
--- a/src/main/java/com/ll/townforest/base/initData/NotProd.java
+++ b/src/main/java/com/ll/townforest/base/initData/NotProd.java
@@ -1,0 +1,192 @@
+package com.ll.townforest.base.initData;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.townforest.boundedContext.account.entity.Account;
+import com.ll.townforest.boundedContext.account.repository.AccountRepository;
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+import com.ll.townforest.boundedContext.apt.entity.AptAccountHouse;
+import com.ll.townforest.boundedContext.apt.entity.House;
+import com.ll.townforest.boundedContext.apt.repository.AptAccountHouseRepository;
+import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
+import com.ll.townforest.boundedContext.apt.repository.AptRepository;
+import com.ll.townforest.boundedContext.apt.repository.HouseRepository;
+
+@Configuration
+@Profile({"dev", "test"})
+public class NotProd {
+	@Bean
+	CommandLineRunner initData(
+		AccountRepository accountRepository,
+		AptAccountRepository aptAccountRepository,
+		AptRepository aptRepository,
+		HouseRepository houseRepository,
+		AptAccountHouseRepository aptAccountHouseRepository
+	) {
+		return new CommandLineRunner() {
+			@Override
+			@Transactional
+			public void run(String... args) throws Exception {
+				Account act = Account.builder()
+					.password("12341234")
+					.username("aaaa")
+					.build();
+				accountRepository.save(act);
+
+				Account account1 = Account.builder()
+					.userId("admin")
+					.password("admin1!")
+					.username("admin")
+					.email("admin@test.com")
+					.phoneNumber("01012345678")
+					.build();
+				accountRepository.save(account1);
+
+				Account account2 = Account.builder()
+					.userId("library")
+					.password("library1!")
+					.username("library admin")
+					.email("forestLibrary@test.com")
+					.phoneNumber("01056781234")
+					.build();
+				accountRepository.save(account2);
+
+				Account account3 = Account.builder()
+					.userId("gym")
+					.password("gym1!")
+					.username("gym admin")
+					.email("gym@test.com")
+					.phoneNumber("01012341234")
+					.build();
+				accountRepository.save(account3);
+
+				Account account4 = Account.builder()
+					.userId("yujin11006")
+					.password("1234")
+					.username("방유진")
+					.email("yujin11006@test.com")
+					.phoneNumber("01000000000")
+					.build();
+				accountRepository.save(account4);
+
+				Account account5 = Account.builder()
+					.userId("bbosong")
+					.password("bbosong1!")
+					.username("이송이")
+					.email("bbosong@test.com")
+					.phoneNumber("01098765432")
+					.build();
+				accountRepository.save(account5);
+
+				Account account6 = Account.builder()
+					.userId("chan")
+					.password("0000")
+					.username("이은찬")
+					.email("chan@test.com")
+					.phoneNumber("01033334444")
+					.build();
+				accountRepository.save(account6);
+
+				Account account7 = Account.builder()
+					.userId("puar12")
+					.password("1234")
+					.username("하울의 무빙 오지는 성")
+					.email("puar12@test.com")
+					.phoneNumber("01099999999")
+					.build();
+				accountRepository.save(account7);
+
+				Apt apt1 = Apt.builder()
+					.name("forest")
+					.maxApartment(1368)
+					.maxDong(9)
+					.maxHo(4)
+					.maxFloor(38)
+					.build();
+				aptRepository.save(apt1);
+
+				// 아파트 동호수 객체 생성
+				for (int i = 1; i <= apt1.getMaxDong(); i++) {
+					for (int j = 1; j <= apt1.getMaxFloor(); j++) {
+						for (int k = 1; j <= apt1.getMaxHo(); k++) {
+							House houseTemp = House.builder()
+								.dong(100 + i)
+								.ho((j * 10) + k)
+								.build();
+							houseRepository.save(houseTemp);
+						}
+					}
+				}
+
+				// 관리자
+				AptAccount aptAccount1 = AptAccount.builder()
+					.account(account1)
+					.apt(apt1)
+					.authority(1)
+					.status(true)
+					.build();
+				aptAccountRepository.save(aptAccount1);
+
+				// 독서실 관리자
+				AptAccount aptAccount2 = AptAccount.builder()
+					.account(account2)
+					.apt(apt1)
+					.authority(2)
+					.status(true)
+					.build();
+				aptAccountRepository.save(aptAccount2);
+
+				//헬스장 관리자
+				AptAccount aptAccount3 = AptAccount.builder()
+					.account(account3)
+					.apt(apt1)
+					.authority(3)
+					.status(true)
+					.build();
+				aptAccountRepository.save(aptAccount3);
+
+				//주민1
+				AptAccount aptAccount4 = AptAccount.builder()
+					.account(account4)
+					.apt(apt1)
+					.status(true)
+					.build();
+				aptAccountRepository.save(aptAccount4);
+
+				//주민2
+				AptAccount aptAccount5 = AptAccount.builder()
+					.account(account5)
+					.apt(apt1)
+					.build();
+				aptAccountRepository.save(aptAccount5);
+
+				//주민3
+				AptAccount aptAccount6 = AptAccount.builder()
+					.account(account4)
+					.apt(apt1)
+					.build();
+				aptAccountRepository.save(aptAccount6);
+
+				//주민4
+				AptAccount aptAccount7 = AptAccount.builder()
+					.account(account7)
+					.apt(apt1)
+					.build();
+				aptAccountRepository.save(aptAccount7);
+
+				//주민과 주거지 연결
+				AptAccountHouse aptAccountHouse1 = AptAccountHouse.builder()
+					.relationship("세대주")
+					.user(aptAccount4)
+					.house(houseRepository.findByDongAndHo(103, 2101))
+					.build();
+				aptAccountHouseRepository.save(aptAccountHouse1);
+			}
+		};
+	}
+}

--- a/src/main/java/com/ll/townforest/base/initData/NotProd.java
+++ b/src/main/java/com/ll/townforest/base/initData/NotProd.java
@@ -98,7 +98,7 @@ public class NotProd {
 				Account account7 = Account.builder()
 					.userId("puar12")
 					.password("1234")
-					.username("하울의 무빙 오지는 성")
+					.username("박철현")
 					.email("puar12@test.com")
 					.phoneNumber("01099999999")
 					.build();
@@ -106,10 +106,10 @@ public class NotProd {
 
 				Apt apt1 = Apt.builder()
 					.name("forest")
-					.maxApartment(1368)
-					.maxDong(9)
+					.maxApartment(500)
+					.maxDong(5)
 					.maxHo(4)
-					.maxFloor(38)
+					.maxFloor(25)
 					.build();
 				aptRepository.save(apt1);
 

--- a/src/main/java/com/ll/townforest/base/initData/NotProd.java
+++ b/src/main/java/com/ll/townforest/base/initData/NotProd.java
@@ -1,5 +1,8 @@
 package com.ll.townforest.base.initData;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -110,19 +113,55 @@ public class NotProd {
 					.build();
 				aptRepository.save(apt1);
 
-				// 아파트 동호수 객체 생성
-				for (int i = 1; i <= apt1.getMaxDong(); i++) {
+				List<House> houseList1 = new ArrayList<>();
+				List<House> houseList2 = new ArrayList<>();
+				List<House> houseList3 = new ArrayList<>();
+
+				// 아파트 동호수 객체 생성 - 첫 번째 1/3
+				int oneThirdDong = apt1.getMaxDong() / 3;
+				for (int i = 1; i <= oneThirdDong; i++) {
 					for (int j = 1; j <= apt1.getMaxFloor(); j++) {
-						for (int k = 1; j <= apt1.getMaxHo(); k++) {
+						for (int k = 1; k <= apt1.getMaxHo(); k++) {
 							House houseTemp = House.builder()
 								.dong(100 + i)
-								.ho((j * 10) + k)
+								.ho((j * 100) + k)
 								.build();
-							houseRepository.save(houseTemp);
+							houseList1.add(houseTemp);
 						}
 					}
 				}
 
+				houseRepository.saveAll(houseList1);
+
+				// 아파트 동호수 객체 생성 - 두 번째 1/3
+				for (int i = oneThirdDong + 1; i <= oneThirdDong * 2; i++) {
+					for (int j = 1; j <= apt1.getMaxFloor(); j++) {
+						for (int k = 1; k <= apt1.getMaxHo(); k++) {
+							House houseTemp = House.builder()
+								.dong(100 + i)
+								.ho((j * 100) + k)
+								.build();
+							houseList2.add(houseTemp);
+						}
+					}
+				}
+
+				houseRepository.saveAll(houseList2);
+
+				// 아파트 동호수 객체 생성 - 세 번째 1/3
+				for (int i = oneThirdDong * 2 + 1; i <= apt1.getMaxDong(); i++) {
+					for (int j = 1; j <= apt1.getMaxFloor(); j++) {
+						for (int k = 1; k <= apt1.getMaxHo(); k++) {
+							House houseTemp = House.builder()
+								.dong(100 + i)
+								.ho((j * 100) + k)
+								.build();
+							houseList3.add(houseTemp);
+						}
+					}
+				}
+
+				houseRepository.saveAll(houseList3);
 				// 관리자
 				AptAccount aptAccount1 = AptAccount.builder()
 					.account(account1)
@@ -167,7 +206,7 @@ public class NotProd {
 
 				//주민3
 				AptAccount aptAccount6 = AptAccount.builder()
-					.account(account4)
+					.account(account6)
 					.apt(apt1)
 					.build();
 				aptAccountRepository.save(aptAccount6);

--- a/src/main/java/com/ll/townforest/boundedContext/account/repository/AccountRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/repository/AccountRepository.java
@@ -1,0 +1,8 @@
+package com.ll.townforest.boundedContext.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.account.entity.Account;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/ll/townforest/boundedContext/apt/entity/Apt.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/entity/Apt.java
@@ -33,4 +33,6 @@ public class Apt {
 	private Integer maxDong;
 	@Column(nullable = false)
 	private Integer maxHo;
+	@Column(nullable = false)
+	private Integer maxFloor;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
@@ -1,0 +1,8 @@
+package com.ll.townforest.boundedContext.apt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.apt.entity.AptAccountHouse;
+
+public interface AptAccountHouseRepository extends JpaRepository<AptAccountHouse, Long> {
+}

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountRepository.java
@@ -1,0 +1,8 @@
+package com.ll.townforest.boundedContext.apt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+
+public interface AptAccountRepository extends JpaRepository<AptAccount, Long> {
+}

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptRepository.java
@@ -1,0 +1,8 @@
+package com.ll.townforest.boundedContext.apt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+
+public interface AptRepository extends JpaRepository<Apt, Long> {
+}

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/HouseRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/HouseRepository.java
@@ -1,0 +1,9 @@
+package com.ll.townforest.boundedContext.apt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.apt.entity.House;
+
+public interface HouseRepository extends JpaRepository<House, Long> {
+	public House findByDongAndHo(Integer Dong, Integer Ho);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,14 +9,14 @@ spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://127.0.0.1:3306/townforest__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
-jpa:
-  hibernate:
-    ddl-auto: create
-  properties:
+  jpa:
     hibernate:
-      show_sql: true
-      format_sql: true
-      use_sql_comments: true
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
 logging:
   level:
     root: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+      jdbc:
+        batch_size=50  # 한번에 DB업로드 할 수 있는 최대 개수 지정, 크면 메모리가 죽어버려.. 50으로 설정
     properties:
       hibernate:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
<!-- pull_request_docs.md 파일은 기본 주소 뒤에 ?template=pull_request_docs.md 를 붙여서 접속합니다. -->
<!-- 예시 : https://github.com/SoloForest/TownForest/compare/main...enhancement1/templates?template=pull_request.docs.md -->

## Description
- NotProd 개발 + test 모드에서 초기 데이터 설정
- NotProd 파일 DB 저장 안되던 버그 수정(apt-account 계정 초기화 중 중복 변수 발견- 1:1 규칙 위반 / 해결)
- for문에서 변수 하나하나 save하니 1368개의 데이터 저장을 하나하나 하여 너무 느리던 현상 해결

<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- **파일경로/파일명**
    - [x] NotProd
      - account, apt, aptAccount, house, aptHouse 활용한 초기 데이터 생성

<!-- "주요 파일"의 변경사항을 작성하고 간단히 로직을 설명합니다. -->

- **base/initData/NotProd.java**
  - [x] 주민4 account 속성 주민1과 중복 문제 해결
  - [x] 아파트 동호수 객체 생성 로직 변경
    - for문을 3개로 나눴으며, 각 for문의 결과를 리스트에 담아서 saveAll로 한번에 저장합니다.
    - batch size를 조절하여 한번에 50개씩 저장하도록 했습니다.(200 도 오버플로우로 죽어버리더라구요..)
 - **resources/application.yml**
   - [x] batchsize 조정 :  한번에 데이터 업로드 할 최대 개수 조정하여 데이터 초기화 속도 증가


### ETC

- 혹시 maxFloor를 줄이는 것이 어떨까요.. 하하 20으로만 줄여도 거의 절반이 줄어들어요..!
(현재 : 1368 / 20층 제한 시 : 720)

- 독서실 Seat 초기화는 송이님 부탁드립니다..!
<!-- 추가 전달사항을 작성합니다. -->

<!-- 예시
#### 주의사항
- ```username : admin, password : admin``` 사용자는 이미 추가되어 있습니다.
-->

---
Close #14 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->