### PR TITLE
Enhancement25/gym

### DIFF
--- a/src/main/java/com/ll/townforest/base/initData/NotProd.java
+++ b/src/main/java/com/ll/townforest/base/initData/NotProd.java
@@ -20,7 +20,9 @@ import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
 import com.ll.townforest.boundedContext.apt.repository.AptRepository;
 import com.ll.townforest.boundedContext.apt.repository.HouseRepository;
 import com.ll.townforest.boundedContext.gym.entity.Gym;
+import com.ll.townforest.boundedContext.gym.entity.GymTicket;
 import com.ll.townforest.boundedContext.gym.repository.GymRepository;
+import com.ll.townforest.boundedContext.gym.repository.GymTicketRepository;
 import com.ll.townforest.boundedContext.library.entity.Library;
 import com.ll.townforest.boundedContext.library.entity.Seat;
 import com.ll.townforest.boundedContext.library.repository.LibraryRepository;
@@ -38,7 +40,8 @@ public class NotProd {
 		AptAccountHouseRepository aptAccountHouseRepository,
 		LibraryRepository libraryRepository,
 		SeatRepository seatRepository,
-		GymRepository gymRepository
+		GymRepository gymRepository,
+		GymTicketRepository gymTicketRepository
 	) {
 		return new CommandLineRunner() {
 			@Override
@@ -259,6 +262,46 @@ public class NotProd {
 					.name("forestGym")
 					.build();
 				gymRepository.save(gym1);
+
+				GymTicket gymTicket1 = GymTicket.builder()
+					.price(1000)
+					.type(1)
+					.apt(apt1)
+					.gym(gym1)
+					.name("1일권")
+					.build();
+
+				gymTicketRepository.save(gymTicket1);
+
+				GymTicket gymTicket2 = GymTicket.builder()
+					.price(30000)
+					.type(2)
+					.apt(apt1)
+					.gym(gym1)
+					.name("30일권")
+					.build();
+
+				gymTicketRepository.save(gymTicket2);
+
+				GymTicket gymTicket3 = GymTicket.builder()
+					.price(54000)
+					.type(3)
+					.content("10% 할인가")
+					.apt(apt1)
+					.gym(gym1)
+					.name("60일권")
+					.build();
+
+				gymTicketRepository.save(gymTicket3);
+				GymTicket gymTicket4 = GymTicket.builder()
+					.price(72000)
+					.type(4)
+					.content("20% 할인가")
+					.apt(apt1)
+					.gym(gym1)
+					.name("90일권")
+					.build();
+				gymTicketRepository.save(gymTicket4);
 			}
 		};
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
@@ -17,13 +17,18 @@ public class GymController {
 	}
 
 	@GetMapping("/locker")
-	public String gymLocker() {
+	public String locker() {
 		return "gym/locker";
 	}
 
 	@GetMapping("/refund")
-	public String gymRefund() {
+	public String refund() {
 		return "gym/refund";
+	}
+
+	@GetMapping("/register")
+	public String register() {
+		return "gym/register";
 	}
 
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
@@ -1,8 +1,14 @@
 package com.ll.townforest.boundedContext.gym.controller;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.ll.townforest.boundedContext.gym.entity.GymTicket;
+import com.ll.townforest.boundedContext.gym.service.GymService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/gym")
 public class GymController {
+
+	private final GymService gymService;
 
 	@GetMapping("")
 	public String gymMain() {
@@ -27,7 +35,12 @@ public class GymController {
 	}
 
 	@GetMapping("/register")
-	public String register() {
+	public String register(Model model) {
+		// 아파트 여러개라면 현재 로그인한 사용자가 속한 Gym ID를 넘긴다.
+		List<GymTicket> gymTicketList = gymService.getGymTickets(1L);
+
+		model.addAttribute("gymTicketList", gymTicketList);
+
 		return "gym/register";
 	}
 

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/Gym.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/Gym.java
@@ -1,11 +1,15 @@
 package com.ll.townforest.boundedContext.gym.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ll.townforest.boundedContext.apt.entity.Apt;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +32,9 @@ public class Gym {
 	private Apt apt;
 
 	private String name;
+
+	@OneToMany
+	@Builder.Default
+	@ToString.Exclude
+	private List<GymTicket> gymTicketList = new ArrayList<>();
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -48,9 +48,10 @@ public class GymHistory {
 	private int paymentMethod;
 	/*
 	이용권 종류
-	0: 30일권
-	1: 60일권
-	2: 90일권
+	0 : 1일권
+	1 : 30일권
+	2 : 60일권
+	3: 90일권
 	*/
 	private int passType;
 	/*

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -48,12 +49,9 @@ public class GymHistory {
 	private int paymentMethod;
 	/*
 	이용권 종류
-	0 : 1일권
-	1 : 30일권
-	2 : 60일권
-	3: 90일권
 	*/
-	private int passType;
+	@OneToOne
+	private GymTicket gymTicket;
 	/*
 	상태
 	0: 결제

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,4 +40,9 @@ public class GymMembership {
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
 	private LocalDateTime paymentDate;
+	// 기간 만료 전에 연장했을 경우 이용권 2개 이상일 테지만, 1:1 관계로 맺음
+	// user와의 관계가 N:1 이므로, 이용권 당 1개의 Membership 객체를 가지면 됨
+	@OneToOne
+	private GymTicket gymTicket;
+
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,10 +38,4 @@ public class GymMembership {
 	private Apt apt;
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
-	private LocalDateTime paymentDate;
-	// 기간 만료 전에 연장했을 경우 이용권 2개 이상일 테지만, 1:1 관계로 맺음
-	// user와의 관계가 N:1 이므로, 이용권 당 1개의 Membership 객체를 가지면 됨
-	@OneToOne
-	private GymTicket gymTicket;
-
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymTicket.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymTicket.java
@@ -1,0 +1,55 @@
+package com.ll.townforest.boundedContext.gym.entity;
+
+import com.ll.townforest.boundedContext.apt.entity.Apt;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class GymTicket {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	/* 이용권 종료를 나타내는 변수
+	1 : 1일권
+	2 : 30일권
+	3 : 60일권
+	4 : 90일권
+	 */
+	@NotNull
+	private Integer type;
+
+	@NotBlank
+	private String name;
+
+	/* 이용권 금액을 나타내는 변수
+	추후 관리자가 할인이벤트를 한다거나, 아니면 이용권을 추가하거나 할 때 사용
+	 */
+	@NotNull
+	private Integer price;
+
+	/* 할인가 정보 */
+	private String content;
+
+	@ManyToOne
+	private Apt apt;
+	@ManyToOne
+	private Gym gym;
+
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymTicketRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymTicketRepository.java
@@ -1,0 +1,11 @@
+package com.ll.townforest.boundedContext.gym.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.townforest.boundedContext.gym.entity.GymTicket;
+
+public interface GymTicketRepository extends JpaRepository<GymTicket, Long> {
+	List<GymTicket> findAllByGymId(Long gymId);
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -1,0 +1,25 @@
+package com.ll.townforest.boundedContext.gym.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.townforest.boundedContext.gym.entity.GymTicket;
+import com.ll.townforest.boundedContext.gym.repository.GymTicketRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GymService {
+	private final GymTicketRepository gymTicketRepository;
+
+	public List<GymTicket> getGymTickets(Long gymId) {
+
+		return gymTicketRepository.findAllByGymId(gymId);
+
+	}
+
+}

--- a/src/main/resources/templates/gym/register.html
+++ b/src/main/resources/templates/gym/register.html
@@ -2,13 +2,15 @@
 
 <head>
     <title layout:title-pattern="$CONTENT_TITLE | $LAYOUT_TITLE">이용권구입</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.6/datepicker.min.js"></script>
+    <link rel="stylesheet" href="/css/calender.css">
+    <script src="/js/calender.js"></script>
+    <script src="https://js.tosspayments.com/v1/payment"></script>
 </head>
 
 <body>
 
-<main layout:fragment="main" class="flex items-center justify-center h-screen">
-    <div class="w-full px-4 flex flex-col">
+<main layout:fragment="main" class="flex items-center justify-center">
+    <div class="px-4 flex flex-col">
         <div class="flex gap-2 items-center justify-center">
             <i class="fa-solid fa-ticket" style="color: #91c0fd;"></i>
             <h2 class="card-title">이용권 구입</h2>
@@ -20,21 +22,12 @@
                 <h2 class="font-bold">이용권 정보</h2>
             </div>
             <div class="form-control flex gap-2 mt-2">
-                <label class="flex items-center gap-2">
-                    <input type="checkbox" class="checkbox checkbox-primary" value="1000"/>
-                    <span class="label-text">1일권 - 1,000원</span>
-                </label>
-                <label class="flex items-center gap-2">
-                    <input type="checkbox" class="checkbox checkbox-primary" value="30000"/>
-                    <span class="label-text">30일권 - 30,000원</span>
-                </label>
-                <label class="flex items-center gap-2">
-                    <input type="checkbox" class="checkbox checkbox-primary" value="54000"/>
-                    <span class="label-text">60일권 - 54,000원(10% 할인가)</span>
-                </label>
-                <label class="flex items-center gap-2">
-                    <input type="checkbox" class="checkbox checkbox-primary" value="72000"/>
-                    <span class="label-text">90일권 - 72,000원(20% 할인가)</span>
+                <label th:each="ticket : ${gymTicketList}" class="flex items-center gap-2">
+                    <input type="checkbox" class="checkbox checkbox-primary" th:value="${ticket.type}"/>
+                    <span class="label-text" th:text="|${ticket.name} - ${#numbers.formatInteger(ticket.price, 3, 'COMMA') + '원'}|"
+                          th:value="${ticket.price}"></span>
+                    <div class="font-bold" th:if="${ticket.content != null}"
+                         th:text="${'(' + ticket.content + ')'}"></div>
                 </label>
             </div>
 
@@ -43,35 +36,49 @@
                     <i class="fa-regular fa-calendar-days" style="color: #91c0fd;"></i>
                     <h2 class="font-bold">이용 시작일 지정</h2>
                 </div>
-                <div class="relative max-w-sx mt-2">
-                    <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                        <svg aria-hidden="true" class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="currentColor"
-                             viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                            <path fill-rule="evenodd"
-                                  d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-                                  clip-rule="evenodd"></path>
-                        </svg>
-                    </div>
-                    <input id="startDate" type="date"
-                           class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-10/12 pl-10 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                           placeholder="이용 시작일을 선택해주세요">
+                <!-- 캘린더 날짜 선택 -->
+                <div class="flex justify-center mt-2">
+                    <table class="Calendar">
+                        <thead>
+                        <tr>
+                            <td onClick="prevCalendar();" style="cursor:pointer;">&#60;</td>
+                            <td colspan="5">
+                                <span id="calYear"></span>년
+                                <span id="calMonth"></span>월
+                            </td>
+                            <td onClick="nextCalendar();" style="cursor:pointer;">&#62;</td>
+                        </tr>
+                        <tr>
+                            <td>일</td>
+                            <td>월</td>
+                            <td>화</td>
+                            <td>수</td>
+                            <td>목</td>
+                            <td>금</td>
+                            <td>토</td>
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        </tbody>
+                    </table>
                 </div>
+                <input id="selectedDate" class="hidden"/>
             </div>
         </div>
-
-
         <div class="flex justify-end wrap items-center gap-2">
             <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
             <p>결제금액 : </p>
             <div id="payment-amount"></div>
         </div>
         <div class="flex justify-end">
-            <button class="btn shadow-xl m-2" style="background-color: #91c0fd;">결제하기</button>
+            <button id="payment-button" class="btn shadow-xl m-2" style="background-color: #91c0fd;">결제하기</button>
         </div>
+    </div>
     </div>
 
     <!-- 체크박스 선택 시 이전 선택한거 삭제 후 선택, 선택된 폰트 굵게 -->
-    <script>
+    <script th:inline="javascript">
         const checkboxes = document.querySelectorAll('.checkbox');
         const paymentAmountElement = document.getElementById('payment-amount');
 
@@ -85,12 +92,18 @@
                         }
                     });
 
+                    // 체크박스 선택된 것의 다음 요소에서 value 속성값을 가져옴
+                    const value = checkbox.nextElementSibling.getAttribute('value');
+                    // 선택된 체크박스의 글꼴을 굵게 설정
                     checkbox.nextElementSibling.classList.add('font-semibold');
-                    const paymentAmount = parseInt(checkbox.value);
+                    // 천단위 구분기호 변환 + 원 붙여주고 글꼴 굵게
+                    const paymentAmount = parseInt(value);
                     const formattedPaymentAmount = paymentAmount.toLocaleString();
                     paymentAmountElement.textContent = formattedPaymentAmount + '원';
                     paymentAmountElement.classList.add('font-semibold');
-                } else {
+                }
+                // 체크박스 선택이 풀렸을 떄
+                else {
                     checkbox.nextElementSibling.classList.remove('font-semibold');
                     paymentAmountElement.textContent = '';
                     paymentAmountElement.classList.remove('font-semibold');

--- a/src/main/resources/templates/gym/register.html
+++ b/src/main/resources/templates/gym/register.html
@@ -1,0 +1,107 @@
+<html layout:decorate="~{home/layout.html}">
+
+<head>
+    <title layout:title-pattern="$CONTENT_TITLE | $LAYOUT_TITLE">이용권구입</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.6/datepicker.min.js"></script>
+</head>
+
+<body>
+
+<main layout:fragment="main" class="flex items-center justify-center h-screen">
+    <div class="w-full px-4 flex flex-col">
+        <div class="flex gap-2 items-center justify-center">
+            <i class="fa-solid fa-ticket" style="color: #91c0fd;"></i>
+            <h2 class="card-title">이용권 구입</h2>
+        </div>
+
+        <div class="card-body bg-base-100 shadow-xl m-2 mt-4">
+            <div class="flex wrap items-center gap-2">
+                <i class="fa-regular fa-calendar-days" style="color: #91c0fd;"></i>
+                <h2 class="font-bold">이용권 정보</h2>
+            </div>
+            <div class="form-control flex gap-2 mt-2">
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" class="checkbox checkbox-primary" value="1000"/>
+                    <span class="label-text">1일권 - 1,000원</span>
+                </label>
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" class="checkbox checkbox-primary" value="30000"/>
+                    <span class="label-text">30일권 - 30,000원</span>
+                </label>
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" class="checkbox checkbox-primary" value="54000"/>
+                    <span class="label-text">60일권 - 54,000원(10% 할인가)</span>
+                </label>
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" class="checkbox checkbox-primary" value="72000"/>
+                    <span class="label-text">90일권 - 72,000원(20% 할인가)</span>
+                </label>
+            </div>
+
+            <div class="mt-4">
+                <div class="flex wrap items-center gap-2">
+                    <i class="fa-regular fa-calendar-days" style="color: #91c0fd;"></i>
+                    <h2 class="font-bold">이용 시작일 지정</h2>
+                </div>
+                <div class="relative max-w-sx mt-2">
+                    <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                        <svg aria-hidden="true" class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="currentColor"
+                             viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                  d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                                  clip-rule="evenodd"></path>
+                        </svg>
+                    </div>
+                    <input id="startDate" type="date"
+                           class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-10/12 pl-10 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                           placeholder="이용 시작일을 선택해주세요">
+                </div>
+            </div>
+        </div>
+
+
+        <div class="flex justify-end wrap items-center gap-2">
+            <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
+            <p>결제금액 : </p>
+            <div id="payment-amount"></div>
+        </div>
+        <div class="flex justify-end">
+            <button class="btn shadow-xl m-2" style="background-color: #91c0fd;">결제하기</button>
+        </div>
+    </div>
+
+    <!-- 체크박스 선택 시 이전 선택한거 삭제 후 선택, 선택된 폰트 굵게 -->
+    <script>
+        const checkboxes = document.querySelectorAll('.checkbox');
+        const paymentAmountElement = document.getElementById('payment-amount');
+
+        checkboxes.forEach(checkbox => {
+            checkbox.addEventListener('change', () => {
+                if (checkbox.checked) {
+                    checkboxes.forEach(c => {
+                        if (c !== checkbox) {
+                            c.checked = false;
+                            c.nextElementSibling.classList.remove('font-semibold');
+                        }
+                    });
+
+                    checkbox.nextElementSibling.classList.add('font-semibold');
+                    const paymentAmount = parseInt(checkbox.value);
+                    const formattedPaymentAmount = paymentAmount.toLocaleString();
+                    paymentAmountElement.textContent = formattedPaymentAmount + '원';
+                    paymentAmountElement.classList.add('font-semibold');
+                } else {
+                    checkbox.nextElementSibling.classList.remove('font-semibold');
+                    paymentAmountElement.textContent = '';
+                    paymentAmountElement.classList.remove('font-semibold');
+                }
+            });
+        });
+
+    </script>
+
+
+</main>
+</body>
+</html>
+


### PR DESCRIPTION
## Description
- GymTicket 엔티티 도입 
  - 토스페이먼츠의 경우 자바스크립트 조작으로 결제금액 조작이 가능합니다.
  - 조작을 스프링부트에서 검증하기 위해 해당 이용권의 금액이 조작 되었는지 검사하기 위해 별도의 Entity를 도입하였습니다.
  - 또한 추후 관리자가 해당 이용권을 조작할 수 도 있을 것 같습니다.(1년권, 이벤트 티켓 등)
 
- NotProd 수정 : GymTicket 초기화를 위한 데이터 추가하였습니다.
-  이용권 구입 View 작성

<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- **base/townforest/base/initData/NotProd**
    - 이용권 정보 검증을 위한 테스트 데이터 추가

- **base/townforest/boundedContext/gym/GymController**
    - 메서드 명 변경
    - 등록 페이지 보여주는 register 메서드에, 이용권 정보를 같이 넘겼습니다.(타임리프 랜더링 위함)
    - 아파트가 늘어난다면, apt_account에 소속된 apt에 gym을 가져와서 해당 ID를 사용해야 할 것 같습니다

- **resources/templates/gym/register**
  - 등록 페이지, 타임리프 랜더링으로 이용권 선택지를 줍니다.
  - 체크박스의 경우 이용권 번호(type)을 가지게 하고, 금액을 나타내는 span 태그에는 이용권 금액을 가집니다.
  - 추후 토스페이먼츠 도입했을 때, 이용권 번호와 금액 정보를 같이 넘겨서 스프링부트에서 검증하고자 합니다!

- **GymTicket 관련**
  - 엔티티 및 관련 컨트롤러 등 추가하였습니다.
  - content의 경우 "비고"란을 의미합니다. 할인가 적용, 이벤트가 등 보여지게 하려 작성했습니다.
  - 다른 테이블과 연관을 맺을까 했지만 복잡성만 증가할 것 같아 제외했습니다.
  - 속성의 중복으로, history와 연관만 맺었습니다!

### ETC
- 토스페이먼츠 주말동안 해보도록 하겠습니다..! 성공하길..!
---
Close #25 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->