### PR TITLE
Enhancement33/library booking

### DIFF
--- a/src/main/java/com/ll/townforest/base/rq/Rq.java
+++ b/src/main/java/com/ll/townforest/base/rq/Rq.java
@@ -76,6 +76,7 @@ public class Rq {
 		if (isLogout())
 			return null;
 
+		getAccount();
 		// 데이터가 없는지 체크
 		if (aptAccount == null) {
 			aptAccount = aptAccountService.findByAccount(account).orElseThrow();

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
 import com.ll.townforest.boundedContext.library.entity.Seat;
@@ -41,16 +42,16 @@ public class LibraryController {
 	//@PreAuthorize("isAuthenticated()")
 	public String Booking(@RequestParam("selectedSeat") int selectedSeat) {
 		Long aptAccountId = 5L;
-		AptAccount user = libraryService.canBooking(aptAccountId);
-		if (user == null) {
-			return "해당 아파트 독서실 이용권한이 없습니다.";
+		RsData<AptAccount> canBookingUser = libraryService.canBooking(aptAccountId);
+		if (canBookingUser.isFail()) {
+			return canBookingUser.getMsg();
 		}
 
-		Seat seat = libraryService.canBooking(selectedSeat);
-		if (seat == null) {
-			return "사용 불가능한 자리입니다.";
+		RsData<Seat> canBookingSeat = libraryService.canBooking(selectedSeat);
+		if (canBookingSeat.isFail()) {
+			return canBookingSeat.getMsg();
 		}
 
-		return libraryService.booking(user, seat, selectedSeat);
+		return libraryService.booking(canBookingUser.getData(), canBookingSeat.getData(), selectedSeat).getMsg();
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -1,7 +1,6 @@
 package com.ll.townforest.boundedContext.library.controller;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -38,11 +37,11 @@ public class LibraryController {
 	//@PreAuthorize("isAuthenticated()")
 	public String showBooking(Model model) {
 		Long aptAccountId = 5L;
-		Optional<LibraryHistory> isUsing = libraryService.lastUsingOfDay(aptAccountId);
+		LibraryHistory isUsing = libraryService.usingHistory(aptAccountId);
 
 		List<Seat> seats = libraryService.findUseableList(1L);
 
-		model.addAttribute("isUsing", isUsing.orElse(null));
+		model.addAttribute("isUsing", isUsing);
 		model.addAttribute("seats", seats);
 		return "library/booking";
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -11,13 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
-import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
-import com.ll.townforest.boundedContext.apt.repository.AptRepository;
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
 import com.ll.townforest.boundedContext.library.entity.Seat;
-import com.ll.townforest.boundedContext.library.repository.LibraryHistoryRepository;
-import com.ll.townforest.boundedContext.library.repository.LibraryRepository;
-import com.ll.townforest.boundedContext.library.repository.SeatRepository;
 import com.ll.townforest.boundedContext.library.service.LibraryService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,11 +22,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/library")
 public class LibraryController {
 	private final LibraryService libraryService;
-	private final AptAccountRepository aptAccountRepository;
-	private final SeatRepository seatRepository;
-	private final LibraryHistoryRepository libraryHistoryRepository;
-	private final AptRepository aptRepository;
-	private final LibraryRepository libraryRepository;
 
 	@GetMapping("/booking")
 	//@PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -52,16 +52,14 @@ public class LibraryController {
 	public String Booking(@RequestParam("selectedSeat") int selectedSeat) {
 		Long aptAccountId = 5L;
 		AptAccount user = libraryService.canBooking(aptAccountId);
-		// Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
-		// if (optAptAccount.isEmpty() || !optAptAccount.get().getApt().getId().equals(1L)) {
-		// 	return "해당 아파트 독서실 이용권한이 없습니다.";
-		// }
+		if (user == null) {
+			return "해당 아파트 독서실 이용권한이 없습니다.";
+		}
 
 		Seat seat = libraryService.canBooking(selectedSeat);
-		// Optional<Seat> optSeat = seatRepository.findBySeatNumber(selectedSeat);
-		// if (optSeat.isEmpty() || optSeat.get().getStatus() != 0) {
-		// 	return "사용 불가능한 자리입니다.";
-		// }
+		if (seat == null) {
+			return "사용 불가능한 자리입니다.";
+		}
 
 		return libraryService.booking(user, seat, selectedSeat);
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -1,9 +1,15 @@
 package com.ll.townforest.boundedContext.library.controller;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
+import com.ll.townforest.boundedContext.library.entity.Seat;
 import com.ll.townforest.boundedContext.library.service.LibraryService;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +22,14 @@ public class LibraryController {
 
 	@GetMapping("/booking")
 	//@PreAuthorize("isAuthenticated()")
-	public String showBooking() {
+	public String showBooking(Model model) {
+		Long aptAccountId = 5L;
+		Optional<LibraryHistory> isUsing = libraryService.lastUsingOfDay(aptAccountId);
+
+		List<Seat> seats = libraryService.findUseableList(1L);
+
+		model.addAttribute("isUsing", isUsing.orElse(null));
+		model.addAttribute("seats", seats);
 		return "library/booking";
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -41,7 +41,7 @@ public class LibraryController {
 	@PostMapping("/booking")
 	@ResponseBody
 	@PreAuthorize("isAuthenticated()")
-	public String Booking(@RequestParam("selectedSeat") int selectedSeat) {
+	public String booking(@RequestParam("selectedSeat") int selectedSeat) {
 		RsData<AptAccount> canBookingUser = libraryService.canBooking(rq.getAptAccount().getId());
 		if (canBookingUser.isFail()) {
 			return canBookingUser.getMsg();

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -2,6 +2,7 @@ package com.ll.townforest.boundedContext.library.controller;
 
 import java.util.List;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.ll.townforest.base.rq.Rq;
 import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
@@ -23,13 +25,12 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/library")
 public class LibraryController {
 	private final LibraryService libraryService;
+	private final Rq rq;
 
 	@GetMapping("/booking")
-	//@PreAuthorize("isAuthenticated()")
+	@PreAuthorize("isAuthenticated()")
 	public String showBooking(Model model) {
-		Long aptAccountId = 5L;
-		LibraryHistory isUsing = libraryService.usingHistory(aptAccountId);
-
+		LibraryHistory isUsing = libraryService.usingHistory(rq.getAptAccount().getId());
 		List<Seat> seats = libraryService.findUseableList(1L);
 
 		model.addAttribute("isUsing", isUsing);
@@ -39,10 +40,9 @@ public class LibraryController {
 
 	@PostMapping("/booking")
 	@ResponseBody
-	//@PreAuthorize("isAuthenticated()")
+	@PreAuthorize("isAuthenticated()")
 	public String Booking(@RequestParam("selectedSeat") int selectedSeat) {
-		Long aptAccountId = 5L;
-		RsData<AptAccount> canBookingUser = libraryService.canBooking(aptAccountId);
+		RsData<AptAccount> canBookingUser = libraryService.canBooking(rq.getAptAccount().getId());
 		if (canBookingUser.isFail()) {
 			return canBookingUser.getMsg();
 		}

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -6,10 +6,19 @@ import java.util.Optional;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
+import com.ll.townforest.boundedContext.apt.repository.AptRepository;
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
 import com.ll.townforest.boundedContext.library.entity.Seat;
+import com.ll.townforest.boundedContext.library.repository.LibraryHistoryRepository;
+import com.ll.townforest.boundedContext.library.repository.LibraryRepository;
+import com.ll.townforest.boundedContext.library.repository.SeatRepository;
 import com.ll.townforest.boundedContext.library.service.LibraryService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +28,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/library")
 public class LibraryController {
 	private final LibraryService libraryService;
+	private final AptAccountRepository aptAccountRepository;
+	private final SeatRepository seatRepository;
+	private final LibraryHistoryRepository libraryHistoryRepository;
+	private final AptRepository aptRepository;
+	private final LibraryRepository libraryRepository;
 
 	@GetMapping("/booking")
 	//@PreAuthorize("isAuthenticated()")
@@ -31,5 +45,25 @@ public class LibraryController {
 		model.addAttribute("isUsing", isUsing.orElse(null));
 		model.addAttribute("seats", seats);
 		return "library/booking";
+	}
+
+	@PostMapping("/booking")
+	@ResponseBody
+	//@PreAuthorize("isAuthenticated()")
+	public String Booking(@RequestParam("selectedSeat") int selectedSeat) {
+		Long aptAccountId = 5L;
+		AptAccount user = libraryService.canBooking(aptAccountId);
+		// Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
+		// if (optAptAccount.isEmpty() || !optAptAccount.get().getApt().getId().equals(1L)) {
+		// 	return "해당 아파트 독서실 이용권한이 없습니다.";
+		// }
+
+		Seat seat = libraryService.canBooking(selectedSeat);
+		// Optional<Seat> optSeat = seatRepository.findBySeatNumber(selectedSeat);
+		// if (optSeat.isEmpty() || optSeat.get().getStatus() != 0) {
+		// 	return "사용 불가능한 자리입니다.";
+		// }
+
+		return libraryService.booking(user, seat, selectedSeat);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/entity/Seat.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/entity/Seat.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 public class Seat {

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
@@ -1,8 +1,15 @@
 package com.ll.townforest.boundedContext.library.repository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
 
 public interface LibraryHistoryRepository extends JpaRepository<LibraryHistory, Long> {
+	Optional<LibraryHistory> findTopByUserIdAndDateBetweenOrderByDateDesc(
+		Long UserId,
+		LocalDateTime startOfDay,
+		LocalDateTime endOfDay);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/SeatRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/SeatRepository.java
@@ -1,6 +1,7 @@
 package com.ll.townforest.boundedContext.library.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import com.ll.townforest.boundedContext.library.entity.Seat;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 	List<Seat> findByLibraryIdAndStatus(Long libraryId, int status);
+
+	Optional<Seat> findBySeatNumber(int seatNumber);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/SeatRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/SeatRepository.java
@@ -1,8 +1,11 @@
 package com.ll.townforest.boundedContext.library.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.townforest.boundedContext.library.entity.Seat;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+	List<Seat> findByLibraryIdAndStatus(Long libraryId, int status);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -7,6 +7,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
+import com.ll.townforest.boundedContext.apt.repository.AptRepository;
 import com.ll.townforest.boundedContext.library.entity.Library;
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
 import com.ll.townforest.boundedContext.library.entity.Seat;
@@ -23,6 +26,8 @@ public class LibraryService {
 	private final LibraryRepository libraryRepository;
 	private final SeatRepository seatRepository;
 	private final LibraryHistoryRepository libraryHistoryRepository;
+	private final AptAccountRepository aptAccountRepository;
+	private final AptRepository aptRepository;
 
 	public List<Seat> findUseableList(Long libraryId) {
 		Optional<Library> optLibrary = libraryRepository.findById(libraryId);
@@ -37,5 +42,34 @@ public class LibraryService {
 
 		return libraryHistoryRepository
 			.findTopByUserIdAndDateBetweenOrderByDateDesc(aptAccountId, startOfDay, endOfDay);
+	}
+
+	public AptAccount canBooking(Long aptAccountId) {
+		Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
+		if (optAptAccount.isEmpty() || !optAptAccount.get().getApt().getId().equals(1L)) {
+			return null; // 해당 아파트 독서실 이용권한이 없습니다.
+		}
+		return optAptAccount.get();
+	}
+
+	public Seat canBooking(int seatNumber) {
+		Optional<Seat> optSeat = seatRepository.findBySeatNumber(seatNumber);
+		if (optSeat.isEmpty() || optSeat.get().getStatus() != 0) {
+			return null; // 사용 불가능한 자리입니다.
+		}
+		return optSeat.get();
+	}
+
+	public String booking(AptAccount user, Seat seat, int selectedSeat) {
+		libraryHistoryRepository.save(LibraryHistory.builder()
+			.apart(aptRepository.findById(1L).orElse(null))
+			.library(libraryRepository.findById(1L).orElse(null))
+			.user(user)
+			.seat(seat)
+			.date(LocalDateTime.now())
+			.statusType(0)
+			.build());
+
+		return "%03d번 좌석을 예약했습니다.".formatted(selectedSeat);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -62,6 +62,12 @@ public class LibraryService {
 		) {
 			return RsData.of("F-1", "해당 아파트 독서실 이용권한이 없습니다.", null);
 		}
+
+		Optional<LibraryHistory> optLibraryHistory = lastUsingOfDay(aptAccountId);
+		if (optLibraryHistory.isPresent() && optLibraryHistory.get().getStatusType().equals(0)) {
+			return RsData.of("F-2", "이미 이용중인 독서실 자리가 있습니다.", null);
+		}
+
 		return RsData.of("S-1", "해당 아파트 독서실 이용에 문제 없는 계정입니다.", optAptAccount.get());
 	}
 

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -82,6 +82,10 @@ public class LibraryService {
 			.statusType(0)
 			.build());
 
+		seatRepository.save(seat.toBuilder()
+			.status(1)
+			.build());
+
 		return "%03d번 좌석을 예약했습니다.".formatted(selectedSeat);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -55,7 +55,10 @@ public class LibraryService {
 
 	public AptAccount canBooking(Long aptAccountId) {
 		Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
-		if (optAptAccount.isEmpty() || !optAptAccount.get().getApt().getId().equals(1L)) {
+		if (optAptAccount.isEmpty()
+			|| !optAptAccount.get().getApt().getId().equals(1L)
+			|| !optAptAccount.get().isStatus()
+		) {
 			return null; // 해당 아파트 독서실 이용권한이 없습니다.
 		}
 		return optAptAccount.get();

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
 import com.ll.townforest.boundedContext.apt.repository.AptRepository;
@@ -36,7 +37,7 @@ public class LibraryService {
 		return seatRepository.findByLibraryIdAndStatus(libraryId, 0);
 	}
 
-	public Optional<LibraryHistory> lastUsingOfDay(Long aptAccountId) {
+	private Optional<LibraryHistory> lastUsingOfDay(Long aptAccountId) {
 		LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
 		LocalDateTime endOfDay = startOfDay.plusDays(1).minusSeconds(1);
 
@@ -53,26 +54,26 @@ public class LibraryService {
 		return optLibraryHistory.get();
 	}
 
-	public AptAccount canBooking(Long aptAccountId) {
+	public RsData<AptAccount> canBooking(Long aptAccountId) {
 		Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
 		if (optAptAccount.isEmpty()
 			|| !optAptAccount.get().getApt().getId().equals(1L)
 			|| !optAptAccount.get().isStatus()
 		) {
-			return null; // 해당 아파트 독서실 이용권한이 없습니다.
+			return RsData.of("F-1", "해당 아파트 독서실 이용권한이 없습니다.", null);
 		}
-		return optAptAccount.get();
+		return RsData.of("S-1", "해당 아파트 독서실 이용에 문제 없는 계정입니다.", optAptAccount.get());
 	}
 
-	public Seat canBooking(int seatNumber) {
+	public RsData<Seat> canBooking(int seatNumber) {
 		Optional<Seat> optSeat = seatRepository.findBySeatNumber(seatNumber);
 		if (optSeat.isEmpty() || optSeat.get().getStatus() != 0) {
-			return null; // 사용 불가능한 자리입니다.
+			return RsData.of("F-1", "사용 불가능한 자리입니다.", null);
 		}
-		return optSeat.get();
+		return RsData.of("S-1", "예약에 문제 없는 자리입니다.", optSeat.get());
 	}
 
-	public String booking(AptAccount user, Seat seat, int selectedSeat) {
+	public RsData<String> booking(AptAccount user, Seat seat, int selectedSeat) {
 		libraryHistoryRepository.save(LibraryHistory.builder()
 			.apart(aptRepository.findById(1L).orElse(null))
 			.library(libraryRepository.findById(1L).orElse(null))
@@ -86,6 +87,6 @@ public class LibraryService {
 			.status(1)
 			.build());
 
-		return "%03d번 좌석을 예약했습니다.".formatted(selectedSeat);
+		return RsData.of("S-1", "%03d번 자리를 예약했습니다.".formatted(selectedSeat));
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -44,6 +44,15 @@ public class LibraryService {
 			.findTopByUserIdAndDateBetweenOrderByDateDesc(aptAccountId, startOfDay, endOfDay);
 	}
 
+	public LibraryHistory usingHistory(Long aptAccountId) {
+		Optional<LibraryHistory> optLibraryHistory = lastUsingOfDay(aptAccountId);
+
+		if (optLibraryHistory.isEmpty() || !optLibraryHistory.get().getStatusType().equals(0)) {
+			return null;
+		}
+		return optLibraryHistory.get();
+	}
+
 	public AptAccount canBooking(Long aptAccountId) {
 		Optional<AptAccount> optAptAccount = aptAccountRepository.findById(aptAccountId);
 		if (optAptAccount.isEmpty() || !optAptAccount.get().getApt().getId().equals(1L)) {

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -1,8 +1,18 @@
 package com.ll.townforest.boundedContext.library.service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
+import com.ll.townforest.boundedContext.library.entity.Library;
+import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
+import com.ll.townforest.boundedContext.library.entity.Seat;
+import com.ll.townforest.boundedContext.library.repository.LibraryHistoryRepository;
 import com.ll.townforest.boundedContext.library.repository.LibraryRepository;
+import com.ll.townforest.boundedContext.library.repository.SeatRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +21,21 @@ import lombok.RequiredArgsConstructor;
 
 public class LibraryService {
 	private final LibraryRepository libraryRepository;
+	private final SeatRepository seatRepository;
+	private final LibraryHistoryRepository libraryHistoryRepository;
+
+	public List<Seat> findUseableList(Long libraryId) {
+		Optional<Library> optLibrary = libraryRepository.findById(libraryId);
+		if (optLibrary.isEmpty())
+			return new ArrayList<Seat>();
+		return seatRepository.findByLibraryIdAndStatus(libraryId, 0);
+	}
+
+	public Optional<LibraryHistory> lastUsingOfDay(Long aptAccountId) {
+		LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+		LocalDateTime endOfDay = startOfDay.plusDays(1).minusSeconds(1);
+
+		return libraryHistoryRepository
+			.findTopByUserIdAndDateBetweenOrderByDateDesc(aptAccountId, startOfDay, endOfDay);
+	}
 }

--- a/src/main/resources/templates/home/main.html
+++ b/src/main/resources/templates/home/main.html
@@ -60,7 +60,7 @@
                 class="btn btn-outline btn-primary">
             헬스장 신청
         </button>
-        <button id="library"
+        <button id="library" onclick="javascript: window.location.href='/library/booking';"
                 class="btn btn-outline btn-primary">
             독서실 자리 예약
         </button>

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -8,13 +8,15 @@
     <!-- 자리 배치 표 -->
     <img src="/librarySeat.png" alt="자리 배치 표" class="mx-[5%]">
     <!-- card ui, 독서실 자리 예약 (로그인 유저가 미이용중일 때) -->
-    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl">
+    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl" th:if="${isUsing == null}">
         <div class="card-body p-3">
             <h2 class="card-title">독서실 자리 예약</h2>
             <form>
                 <select class="select select-bordered w-full my-2">
                     <option disabled selected>예약 가능한 자리</option>
-                    <option>001번</option>
+                    <th:block th:each="seat : ${seats}">
+                        <option th:text="${#numbers.formatInteger(seat.seatNumber,3)} + '번'"></option>
+                    </th:block>
                 </select>
             </form>
             <div class="card-actions justify-end">
@@ -23,10 +25,12 @@
         </div>
     </div>
     <!-- card ui, 독서실 이용중 예약한 자리 번호 (로그인 유저가 이용중일 때) -->
-    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl">
+    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl" th:if="${isUsing != null}">
         <div class="card-body p-3">
             <h2 class="card-title">독서실 자리 예약</h2>
-            <p class="text-center my-2"><b>001</b>번 좌석을 이용중입니다.</p>
+            <p class="text-center my-2">
+                <b th:text="${#numbers.formatInteger(isUsing.seat.seatNumber,3)}"></b>번 좌석을 이용중입니다.
+            </p>
             <div class="card-actions justify-end">
                 <button class="btn btn-info btn-sm text-white">취소하기</button>
             </div>

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -1,6 +1,8 @@
 <html layout:decorate="~{home/layout.html}">
 <head>
-    <title layout:title-pattern="$CONTENT_TITLE | $LAYOUT_TITLE">독서실 이용</title>
+    <title>독서실 이용</title>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}">
+    <meta name="_csrf" th:content="${_csrf.token}">
 </head>
 <body>
 <!-- main -->
@@ -11,17 +13,19 @@
     <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl" th:if="${isUsing == null}">
         <div class="card-body p-3">
             <h2 class="card-title">독서실 자리 예약</h2>
-            <form>
-                <select class="select select-bordered w-full my-2">
+            <form th:action="|/library/booking|" method="POST" onsubmit="event.preventDefault(); submitBooking(this);">
+
+                <select class="select select-bordered w-full my-2" name="selectedSeat">
                     <option disabled selected>예약 가능한 자리</option>
                     <th:block th:each="seat : ${seats}">
                         <option th:text="${#numbers.formatInteger(seat.seatNumber,3)} + '번'"></option>
                     </th:block>
                 </select>
+
+                <div class="card-actions justify-end">
+                    <button class="btn btn-info btn-sm text-white">예약하기</button>
+                </div>
             </form>
-            <div class="card-actions justify-end">
-                <button class="btn btn-info btn-sm text-white">예약하기</button>
-            </div>
         </div>
     </div>
     <!-- card ui, 독서실 이용중 예약한 자리 번호 (로그인 유저가 이용중일 때) -->
@@ -115,6 +119,34 @@
             </div>
         </div>
     </div>
+    <script>
+        function submitBooking(form) {
+            let header = $("meta[name='_csrf_header']").attr('content');
+            let token = $("meta[name='_csrf']").attr('content');
+            let selectedSeat = form.selectedSeat.value.slice(0, -1);
+
+            // AJAX 요청
+            $.ajax({
+                type: 'POST',
+                url: form.action,
+                data: {
+                    _csrf: form._csrf.value,
+                    selectedSeat: selectedSeat
+                },
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader(header, token);
+                },
+                success: function (result) {
+                    alert(result);
+                    window.location.reload();
+                },
+                error: function (xhr, textStatus, errorThrown) {
+                    console.error('Error: ' + errorThrown);
+                    alert('Error: 예약에 실패했습니다.');
+                }
+            });
+        }
+    </script>
 </main>
 </body>
 </html>

--- a/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
+++ b/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
@@ -1,0 +1,99 @@
+package com.ll.townforest.boundedContext.library.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class LibraryControllerTests {
+	@Autowired
+	private MockMvc mvc;
+
+	@Test
+	@DisplayName("독서실 자리 예약 폼")
+	void t001() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(get("/library/booking"))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("showBooking"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("**/account/login"));
+	}
+
+	@Test
+	@DisplayName("독서실 자리 예약 폼")
+	@WithUserDetails("yujin11006")
+	void t002() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(get("/library/booking"))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("showBooking"))
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(view().name("library/booking"));
+	}
+
+	@Test
+	@DisplayName("독서실 자리 예약")
+	@WithUserDetails("bbosong")
+	void t003() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/library/booking")
+				.with(csrf())
+				.param("selectedSeat", "1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("booking"))
+			.andExpect(status().is2xxSuccessful());
+
+		assertThat(resultActions.andReturn().getResponse().getContentAsString())
+			.isEqualTo("해당 아파트 독서실 이용권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("독서실 자리 예약")
+	@WithUserDetails("yujin11006")
+	void t004() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/library/booking")
+				.with(csrf())
+				.param("selectedSeat", "1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("booking"))
+			.andExpect(status().is2xxSuccessful());
+
+		assertThat(resultActions.andReturn().getResponse().getContentAsString())
+			.isEqualTo("001번 자리를 예약했습니다.");
+	}
+}


### PR DESCRIPTION
## Description
- 사용자가 독서실 자리를 사용중일 때, 몇번 자리를 사용하는지 보여주도록 함
- 미사용중일 때, 사용 가능한 자리 리스트에서 자리를 선택해 예약할 수 있는 화면을 보여주도록 함
- 예약하기 버튼을 누르면 사용자가 자리를 사용하는것을 표시하도록 서버 데이터(LibraryHistory, Seat)를 변경함
- Rq, RsData 도입
- test 생성

## Changes

- **boundedContext/library/service/LibraryService.java**
    - lastUsingOfDay()
        - [x] 현재 날짜에, 해당 유저가 마지막으로 남긴 독서실 히스토리를 반환합니다.
    - usingHistory()
        - [x] 로그인 이용자가 오늘 남긴 마지막 히스토리의 statusType이 0(예약)이면 해당 히스토리를 반환,
        - [x] 아니라면 null을 반환합니다.
    - canBooking()
        - param : Long aptAccountId
            - [x] 로그인한 계정이 해당 아파트 입주민인지 검증합니다.(aptId를 써야하지만, 아파트가 하나이기 때문에 하드코딩 했습니다.)
            - [x] 로그인한 계정이 이미 다른 자리를 사용중인지 검증합니다.
        - param : int seatNumber
            - [x] 정말로 사용 가능한 자리인지 검증합니다.
    - booking()
        - [x] 새로운 예약 히스토리를 생성합니다.
        - [x] 좌석의 상태를 사용중으로 변경합니다.

- **boundedContext/library/controller/LibraryController.java**
    - showBooking()
        - [x] 히스토리 조회로 로그인 이용자가 이용중인 자리가 있는지 확인합니다.
        - [x] 좌석 조회로 예약 가능한 자리 리스트를 생성합니다.
        - [ ] **히스토리 조회로 로그인 이용자의 히스토리 리스트를 페이징으로 생성합니다.** -> Next ToDo입니다.
    - booking()
        - [x] 예약 가능한 계정인지 확인합니다.
        - [x] 예약 가능한 자리인지 확인합니다.
        - [x] 예약 가능한 계정과 자리일 때, 히스토리를 생성하고 자리를 할당합니다. 

- **templates/library/booking.html**
    - [x] 로그인 이용자가 자리를 사용중인지, 아닌지 판단하여 각각 다른 '독서실 자리 예약' card ui를 보여줍니다.
    - [x] 각각의 내용을 타임리프 문법을 사용해 동적으로 보여줍니다.
    - [ ] **로그인 이용자의 이용 내역을 페이징하여 보여줍니다.** -> Next ToDo입니다.
    - 해당 페이지에서 사용하는 JS 코드는 범용성이 없다고 판단하여 따로 js파일로 분리하지 않았습니다.  
      이견 있으시면 말씀해주세용!

### ETC

커밋이랑 파일체인지가 좀 많아보이긴 하는데 사실 별 내용 없습니다..!  
Changes에 적은 내용을 중점으로 봐주세요!

그리고 저는 태스트 작성할 때,  
로그인 없이 접속 불가능한 페이지로 접근한 경우의 검증에   
```redirectionUrl("/account/login")```하면 절대경로가 아니고 테스트 통과가 안되더라고요!   
혹시 이유를 아시는 분이나 같은 문제가 있으셨던 분 계신가요?

---
Close #33 