### PR TITLE
Enhancement42/library cancel

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -6,6 +6,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -53,5 +54,22 @@ public class LibraryController {
 		}
 
 		return libraryService.booking(canBookingUser.getData(), canBookingSeat.getData(), selectedSeat).getMsg();
+	}
+
+	@PostMapping("/cancel/{seatNumber}")
+	@ResponseBody
+	@PreAuthorize("isAuthenticated()")
+	public String cancel(@PathVariable int seatNumber) {
+		RsData<AptAccount> canCancelUser = libraryService.canCancel(rq.getAptAccount().getId());
+		if (canCancelUser.isFail()) {
+			return canCancelUser.getMsg();
+		}
+
+		RsData<Seat> canCancelSeat = libraryService.canCancel(seatNumber);
+		if (canCancelSeat.isFail()) {
+			return canCancelSeat.getMsg();
+		}
+
+		return libraryService.cancel(canCancelUser.getData(), canCancelSeat.getData(), seatNumber).getMsg();
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -6,7 +6,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,10 +55,10 @@ public class LibraryController {
 		return libraryService.booking(canBookingUser.getData(), canBookingSeat.getData(), selectedSeat).getMsg();
 	}
 
-	@PostMapping("/cancel/{seatNumber}")
+	@PostMapping("/cancel")
 	@ResponseBody
 	@PreAuthorize("isAuthenticated()")
-	public String cancel(@PathVariable int seatNumber) {
+	public String cancel(@RequestParam int seatNumber) {
 		RsData<AptAccount> canCancelUser = libraryService.canCancel(rq.getAptAccount().getId());
 		if (canCancelUser.isFail()) {
 			return canCancelUser.getMsg();

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
@@ -79,6 +80,7 @@ public class LibraryService {
 		return RsData.of("S-1", "예약에 문제 없는 자리입니다.", optSeat.get());
 	}
 
+	@Transactional
 	public RsData<String> booking(AptAccount user, Seat seat, int selectedSeat) {
 		libraryHistoryRepository.save(LibraryHistory.builder()
 			.apart(aptRepository.findById(1L).orElse(null))
@@ -125,6 +127,7 @@ public class LibraryService {
 		return RsData.of("S-1", "예약 취소 가능한 자리입니다.", optSeat.get());
 	}
 
+	@Transactional
 	public RsData<String> cancel(AptAccount user, Seat seat, int selectedSeat) {
 		libraryHistoryRepository.save(LibraryHistory.builder()
 			.apart(aptRepository.findById(1L).orElse(null))

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -33,10 +33,13 @@
         <div class="card-body p-3">
             <h2 class="card-title">독서실 자리 예약</h2>
             <p class="text-center my-2">
-                <b th:text="${#numbers.formatInteger(isUsing.seat.seatNumber,3)}"></b>번 좌석을 이용중입니다.
+                <b id="usingSeatNum" th:text="${#numbers.formatInteger(isUsing.seat.seatNumber,3)}"></b>번 좌석을 이용중입니다.
             </p>
             <div class="card-actions justify-end">
-                <button class="btn btn-info btn-sm text-white">취소하기</button>
+                <button class="btn btn-info btn-sm text-white"
+                        onclick="event.preventDefault(); submitCancel();">
+                    취소하기
+                </button>
             </div>
         </div>
     </div>
@@ -143,6 +146,30 @@
                 error: function (xhr, textStatus, errorThrown) {
                     console.error('Error: ' + errorThrown);
                     alert('Error: 예약에 실패했습니다.');
+                }
+            });
+        }
+
+        function submitCancel() {
+            let header = $("meta[name='_csrf_header']").attr('content');
+            let token = $("meta[name='_csrf']").attr('content');
+            let seatNumber = document.getElementById("usingSeatNum").innerText * 1;
+
+            // AJAX 요청
+            $.ajax({
+                type: 'POST',
+                url: '/library/cancel/' + seatNumber,
+                data: {},
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader(header, token);
+                },
+                success: function (result) {
+                    alert(result);
+                    window.location.reload();
+                },
+                error: function (xhr, textStatus, errorThrown) {
+                    console.error('Error: ' + errorThrown);
+                    alert('Error: 예약 취소에 실패했습니다.');
                 }
             });
         }

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -158,8 +158,10 @@
             // AJAX 요청
             $.ajax({
                 type: 'POST',
-                url: '/library/cancel/' + seatNumber,
-                data: {},
+                url: '/library/cancel',
+                data: {
+                    seatNumber: seatNumber
+                },
                 beforeSend: function (xhr) {
                     xhr.setRequestHeader(header, token);
                 },

--- a/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
+++ b/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
@@ -112,7 +112,7 @@ public class LibraryControllerTests {
 			.andExpect(status().is2xxSuccessful());
 
 		assertThat(resultActions.andReturn().getResponse().getContentAsString())
-			.isEqualTo("이용중인 자리가 아닙니다.");
+			.isEqualTo("이용중인 독서실 자리가 없습니다.");
 	}
 
 	@Test

--- a/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
+++ b/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
@@ -102,7 +102,7 @@ public class LibraryControllerTests {
 	@WithUserDetails("yujin11006")
 	void t005() throws Exception {
 		ResultActions resultActions = mvc
-			.perform(post("/library/cancel/1")
+			.perform(post("/library/cancel")
 				.with(csrf()))
 			.andDo(print());
 
@@ -122,7 +122,7 @@ public class LibraryControllerTests {
 		mvc.perform(post("/library/booking").with(csrf()).param("selectedSeat", "1")).andDo(print());
 
 		ResultActions resultActions = mvc
-			.perform(post("/library/cancel/1")
+			.perform(post("/library/cancel")
 				.with(csrf()))
 			.andDo(print());
 

--- a/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
+++ b/src/test/java/com/ll/townforest/boundedContext/library/controller/LibraryControllerTests.java
@@ -96,4 +96,42 @@ public class LibraryControllerTests {
 		assertThat(resultActions.andReturn().getResponse().getContentAsString())
 			.isEqualTo("001번 자리를 예약했습니다.");
 	}
+
+	@Test
+	@DisplayName("독서실 자리 예약 취소")
+	@WithUserDetails("yujin11006")
+	void t005() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/library/cancel/1")
+				.with(csrf()))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("cancel"))
+			.andExpect(status().is2xxSuccessful());
+
+		assertThat(resultActions.andReturn().getResponse().getContentAsString())
+			.isEqualTo("이용중인 자리가 아닙니다.");
+	}
+
+	@Test
+	@DisplayName("독서실 자리 예약 취소")
+	@WithUserDetails("yujin11006")
+	void t006() throws Exception {
+		mvc.perform(post("/library/booking").with(csrf()).param("selectedSeat", "1")).andDo(print());
+
+		ResultActions resultActions = mvc
+			.perform(post("/library/cancel/1")
+				.with(csrf()))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(LibraryController.class))
+			.andExpect(handler().methodName("cancel"))
+			.andExpect(status().is2xxSuccessful());
+
+		assertThat(resultActions.andReturn().getResponse().getContentAsString())
+			.isEqualTo("001번 자리 이용을 취소합니다.");
+	}
 }


### PR DESCRIPTION
<!-- pull_request_docs.md 파일은 기본 주소 뒤에 ?template=pull_request_docs.md 를 붙여서 접속합니다. -->
<!-- 예시 : https://github.com/SoloForest/TownForest/compare/main...enhancement1/templates?template=pull_request.docs.md -->

## Description
독서실 자리 예약 취소 기능을 구현했습니다.

## Changes
- **boundedContext/library/service/LibraryService.java**
    - canCancel()
        - param : Long aptAccountId
            - [x] 로그인한 계정이 해당 아파트 입주민인지 검증합니다.
            - [x] 로그인한 계정이 이용중인 자리가 있는지 검증합니다.
            - [x] 로그인한 계정이 이용중인 자리가 맞는지 검증합니다.
        - param : int seatNumber
            - [x] 이용중인자리인지 검증합니다.

- **boundedContext/library/controller/LibraryController.java**
    - cancel()
        - API 34번
        - [x] 자리를 이용중인 계정인지 확인합니다.
        - [x] 로그인 이용자가 이용중인 자리에 대한 요청인지 확인합니다. 
        - [x] 로그인 이용자가 이용중인 자리를 반납(예약 취소)합니다.

- **resources/templates/library/booking.html**
    - submitCancel()
      - [x] Post요청을 보냅니다.
      - seatNumber변수 저장할 때, document...에 1을 곱한 이유는 숫자로만 이루어진 문자열에 1을 곱하면 숫자로 변경되기 때문입니다!


### ETC
API 34번 원래 method가 Delete였는데 히스토리 추가 로직도 있어서 Post로 변경했어요!

---
Close #42 