### PR TITLE
Enhancement43/library histories

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/controller/LibraryController.java
@@ -2,6 +2,8 @@ package com.ll.townforest.boundedContext.library.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -32,10 +34,20 @@ public class LibraryController {
 	public String showBooking(Model model) {
 		LibraryHistory isUsing = libraryService.usingHistory(rq.getAptAccount().getId());
 		List<Seat> seats = libraryService.findUseableList(1L);
+		Slice<LibraryHistory> histories = libraryService.findHistories(rq.getAptAccount().getId(),
+			PageRequest.of(0, 5));
 
 		model.addAttribute("isUsing", isUsing);
 		model.addAttribute("seats", seats);
+		model.addAttribute("histories", histories);
 		return "library/booking";
+	}
+
+	@PostMapping("/histories")
+	@ResponseBody
+	@PreAuthorize("isAuthenticated()")
+	public Slice<LibraryHistory> pagingHistories(@RequestParam int page, @RequestParam int size) {
+		return libraryService.findHistories(rq.getAptAccount().getId(), PageRequest.of(page, size));
 	}
 
 	@PostMapping("/booking")

--- a/src/main/java/com/ll/townforest/boundedContext/library/entity/LibraryHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/entity/LibraryHistory.java
@@ -57,4 +57,13 @@ public class LibraryHistory {
 	 * */
 	@Column(nullable = false)
 	private Integer statusType;
+
+	public String getStatusTypeToString() {
+		return switch (statusType) {
+			case 0 -> "예약";
+			case 1 -> "취소";
+			case 2 -> "자동취소";
+			default -> "";
+		};
+	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
@@ -3,6 +3,8 @@ package com.ll.townforest.boundedContext.library.repository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
@@ -12,4 +14,6 @@ public interface LibraryHistoryRepository extends JpaRepository<LibraryHistory, 
 		Long UserId,
 		LocalDateTime startOfDay,
 		LocalDateTime endOfDay);
+
+	Slice<LibraryHistory> findByUserIdOrderByIdDesc(Long aptAccountId, Pageable pageable);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -143,5 +145,9 @@ public class LibraryService {
 			.build());
 
 		return RsData.of("S-1", "%03d번 자리 이용을 취소합니다.".formatted(selectedSeat));
+	}
+
+	public Slice<LibraryHistory> findHistories(Long aptAccountId, Pageable pageable) {
+		return libraryHistoryRepository.findByUserIdOrderByIdDesc(aptAccountId, pageable);
 	}
 }

--- a/src/main/resources/static/js/dateUtil.js
+++ b/src/main/resources/static/js/dateUtil.js
@@ -1,0 +1,9 @@
+function dateFormat(dateString) {
+    const date = new Date(dateString);
+    return date.getFullYear() +
+        '.' + ((date.getMonth() + 1) < 9 ? "0" + (date.getMonth() + 1) : (date.getMonth() + 1)) +
+        '.' + (date.getDate() < 10 ? "0" + date.getDate() : date.getDate()) +
+        ' ' + (date.getHours() < 10 ? "0" + date.getHours() : date.getHours()) +
+        ':' + (date.getMinutes() < 10 ? "0" + date.getMinutes() : date.getMinutes()) +
+        ':' + (date.getSeconds() < 10 ? "0" + date.getSeconds() : date.getSeconds());
+}

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -72,6 +72,7 @@
                 </table>
                 <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
                 <button id="more" class="btn btn-info btn-outline btn-sm w-full"
+                        th:if="${histories.numberOfElements} >= 5"
                         onclick="event.preventDefault(); loadHistories()">
                     더보기
                 </button>

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -1,6 +1,7 @@
 <html layout:decorate="~{home/layout.html}">
 <head>
     <title>독서실 이용</title>
+    <script src="/js/dateUtil.js"></script>
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
     <meta name="_csrf" th:content="${_csrf.token}">
 </head>
@@ -66,7 +67,7 @@
                     <tbody id="contentList">
                     <!-- row 1 -->
                     <tr th:each="history : ${histories}">
-                        <td th:text="${history.date}"></td>
+                        <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
                         <td th:text="${history.seat.seatNumber}"></td>
                         <td th:text="${history.getStatusTypeToString()}"></td>
                     </tr>
@@ -105,7 +106,7 @@
                     // 결과가 성공적으로 수신되면 테이블에 로우 추가
                     $.each(data.content, function (index, history) {
                         let newRow = `<tr>
-                        <td>${history.date}</td>
+                        <td>${dateFormat(history.date)}</td>
                         <td>${history.seat.seatNumber}</td>
                         <td>${history.statusTypeToString}</td>
                       </tr>`;

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -48,7 +48,10 @@
         <div class="card-body p-3">
             <h2 class="card-title">이용 내역</h2>
 
-            <div class="overflow-x-auto">
+            <P th:if="${histories.numberOfElements} == 0" class="text-center my-5">
+                독서실 이용 내역이 없습니다.
+            </P>
+            <div class="overflow-x-auto" th:if="${histories.numberOfElements} != 0">
                 <table class="table text-center">
                     <!-- head -->
                     <thead>

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -60,69 +60,63 @@
                     </thead>
 
                     <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
-                    <tbody>
+                    <tbody id="contentList">
                     <!-- row 1 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>예약</td>
-                    </tr>
-                    <!-- row 2 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>취소</td>
-                    </tr>
-                    <!-- row 3 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>예약</td>
-                    </tr>
-                    <!-- row 4 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>취소</td>
-                    </tr>
-                    <!-- row 5 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>예약</td>
-                    </tr>
-                    <!-- row 6 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>취소</td>
-                    </tr>
-                    <!-- row 7 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>예약</td>
-                    </tr>
-                    <!-- row 8 -->
-                    <tr>
-                        <td>2023.06.27</td>
-                        <td>001</td>
-                        <td>자동취소</td>
-                    </tr>
-                    <!-- row 9 -->
-                    <tr>
-                        <td>2023.06.26</td>
-                        <td>001</td>
-                        <td>예약</td>
+                    <tr th:each="history : ${histories}">
+                        <td th:text="${history.date}"></td>
+                        <td th:text="${history.seat.seatNumber}"></td>
+                        <td th:text="${history.getStatusTypeToString()}"></td>
                     </tr>
                     </tbody>
+
                 </table>
                 <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
-                <button id="more" class="btn btn-info btn-outline btn-sm w-full">더보기</button>
+                <button id="more" class="btn btn-info btn-outline btn-sm w-full"
+                        onclick="event.preventDefault(); loadHistories()">
+                    더보기
+                </button>
             </div>
         </div>
     </div>
     <script>
+        const numRows = 5; // 한 번에 가져오고자 하는 로우의 개수
+        let currPage = 0; // 현재 페이지 카운터
+
+        function loadHistories() {
+            let header = $("meta[name='_csrf_header']").attr('content');
+            let token = $("meta[name='_csrf']").attr('content');
+            currPage++; // 페이지 카운터 증가
+
+            $.ajax({
+                url: '/library/histories',
+                type: 'POST',
+                data: {
+                    page: currPage,
+                    size: numRows
+                },
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader(header, token);
+                },
+                success: function (data) {
+                    // 결과가 성공적으로 수신되면 테이블에 로우 추가
+                    $.each(data.content, function (index, history) {
+                        let newRow = `<tr>
+                        <td>${history.date}</td>
+                        <td>${history.seat.seatNumber}</td>
+                        <td>${history.statusTypeToString}</td>
+                      </tr>`;
+                        $('#contentList').append(newRow);
+                    });
+                    if (data.last) {
+                        $('#more').addClass("hidden");
+                    }
+                },
+                error: function (err) {
+                    console.log("Error fetching data:", err);
+                }
+            });
+        }
+
         function submitBooking(form) {
             let header = $("meta[name='_csrf_header']").attr('content');
             let token = $("meta[name='_csrf']").attr('content');

--- a/src/main/resources/templates/library/booking.html
+++ b/src/main/resources/templates/library/booking.html
@@ -76,7 +76,7 @@
                 </table>
                 <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
                 <button id="more" class="btn btn-info btn-outline btn-sm w-full"
-                        th:if="${histories.numberOfElements} >= 5"
+                        th:if="${histories.last} == false"
                         onclick="event.preventDefault(); loadHistories()">
                     더보기
                 </button>


### PR DESCRIPTION
## Description
로그인 이용자의 독서실 자리 이용 내역을 출력합니다.

## Changes

- **boundedContext/library/controller/LibraryController.java**
    - showBooking()
        - API 32번
        - [x] 히스토리 조회로 로그인 이용자의 최근 독서실 이용 내역을 5개 출력합니다.
            - 넘버링할 필요가 없기 때문에 Page 대신 Slice 자료형을 사용했습니다.
            - Page는 전체 페이지 개수가 계산됩니다.
    - pagingHistories()
        - [x] 히스토리 조회로 로그인 이용자의 자리 이용 내역을 5개씩 불러옵니다.

- **boundedContext/library/service/LibraryService.java**
    - findHistories()
        - [x] 로그인 이용자의 히스토리를 최신순으로 조회해서 Slice 페이지 방식으로 반환합니다.

- **resources/templates/library/booking.html**  
    - 독서실 이용 히스토리가 5개 미만이면 '더보기'버튼을 출력하지 않습니다.  
    - 독서실 이용 히스토리가 존재하지 않으면 테이블 대신 안내메시지를 출력합니다. 
    - loadHistories()  
        - [x] '더보기'버튼을 클릭하면 이전 내역 5개가 더 출력됩니다.  
        - [x] 더이상 표시할 히스토리가 없다면 '더보기'버튼을 없앱니다.  

- **resources/static/js/dateUtil.js**
    - dateFormat()
        - [x] 컨트롤러에서 String으로 받아온 날짜를 'yyyy.MM.dd HH:mm:ss'형식으로 변환합니다.

### ETC
Page와 Slice에 대해 참고한 글 공유합니다! [(여기)](https://hudi.blog/spring-data-jpa-pagination)

---
Close #43 