### PR TITLE
Enhancement48/admin library histories

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
@@ -1,8 +1,11 @@
 package com.ll.townforest.boundedContext.apt.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.townforest.boundedContext.apt.entity.AptAccountHouse;
 
 public interface AptAccountHouseRepository extends JpaRepository<AptAccountHouse, Long> {
+	Optional<AptAccountHouse> findByUserId(Long id);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -71,7 +71,7 @@ public class AdminController {
 			return canCancelSeat.getMsg();
 		}
 
-		AptAccount targetUser = libraryService.getTargetUser(libraryHistoryId);
+		AptAccount targetUser = libraryService.getTargetUserForAdminCancel(libraryHistoryId);
 
 		return libraryService.AdminCancel(targetUser, canCancelSeat.getData(), libraryHistoryId).getMsg();
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -73,6 +73,6 @@ public class AdminController {
 
 		AptAccount targetUser = libraryService.getTargetUserForAdminCancel(libraryHistoryId);
 
-		return libraryService.AdminCancel(targetUser, canCancelSeat.getData(), libraryHistoryId).getMsg();
+		return libraryService.adminCancel(targetUser, canCancelSeat.getData(), libraryHistoryId).getMsg();
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -1,11 +1,22 @@
 package com.ll.townforest.boundedContext.home.controller;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.ll.townforest.base.rq.Rq;
+import com.ll.townforest.base.rsData.RsData;
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+import com.ll.townforest.boundedContext.library.entity.LibraryHistory;
+import com.ll.townforest.boundedContext.library.entity.Seat;
+import com.ll.townforest.boundedContext.library.service.LibraryService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/admin")
 public class AdminController {
 	private final Rq rq;
+	private final LibraryService libraryService;
 
 	@GetMapping("")
 	@PreAuthorize("isAuthenticated()")
@@ -22,5 +34,45 @@ public class AdminController {
 			return "redirect:/";
 		}
 		return "admin/main";
+	}
+
+	@GetMapping("/library/histories")
+	@PreAuthorize("isAuthenticated()")
+	public String showLibraryHistories(Model model) {
+		if (rq.getAptAccount().getAuthority() == 0) {
+			return "redirect:/";
+		}
+
+		if (rq.getAptAccount().getAuthority() == 3) {
+			return "redirect:/admin";
+		}
+
+		Slice<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(0, 25));
+		model.addAttribute("histories", histories);
+		return "admin/library/histories";
+	}
+
+	@PostMapping("/library/histories")
+	@ResponseBody
+	public Slice<LibraryHistory> libraryHistories(@RequestParam int page, @RequestParam int size) {
+		return libraryService.findAllHistories(PageRequest.of(page, size));
+	}
+
+	@PostMapping("/library/cancel")
+	@ResponseBody
+	public String libraryBookingCancel(@RequestParam Long libraryHistoryId) {
+		RsData<AptAccount> canCancelUser = libraryService.canAdminCancel(rq.getAptAccount());
+		if (canCancelUser.isFail()) {
+			return canCancelUser.getMsg();
+		}
+
+		RsData<Seat> canCancelSeat = libraryService.canAdminCancel(libraryHistoryId);
+		if (canCancelSeat.isFail()) {
+			return canCancelSeat.getMsg();
+		}
+
+		AptAccount targetUser = libraryService.getTargetUser(libraryHistoryId);
+
+		return libraryService.AdminCancel(targetUser, canCancelSeat.getData(), libraryHistoryId).getMsg();
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -1,0 +1,22 @@
+package com.ll.townforest.boundedContext.home.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+	@GetMapping("")
+	public String showAdmin() {
+		return "admin/main";
+	}
+
+	@GetMapping("/library/histories")
+	public String showLibraryHistories() {
+		return "admin/library/histories";
+	}
+}

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -1,8 +1,11 @@
 package com.ll.townforest.boundedContext.home.controller;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.ll.townforest.base.rq.Rq;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
-	@GetMapping("")
-	public String showAdmin() {
-		return "admin/main";
-	}
+	private final Rq rq;
 
-	@GetMapping("/library/histories")
-	public String showLibraryHistories() {
-		return "admin/library/histories";
+	@GetMapping("")
+	@PreAuthorize("isAuthenticated()")
+	public String showAdmin() {
+		if (rq.getAptAccount().getAuthority() == 0) {
+			return "redirect:/";
+		}
+		return "admin/main";
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/entity/LibraryHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/entity/LibraryHistory.java
@@ -44,6 +44,9 @@ public class LibraryHistory {
 	@ManyToOne
 	private AptAccount user;
 
+	@Column(nullable = false)
+	private String addressToString;
+
 	@ManyToOne
 	private Seat seat;
 
@@ -54,6 +57,7 @@ public class LibraryHistory {
 	 * 0: 예약
 	 * 1: 취소(반납)
 	 * 2: 자동취소
+	 * 3: 관리자취소
 	 * */
 	@Column(nullable = false)
 	private Integer statusType;
@@ -63,6 +67,7 @@ public class LibraryHistory {
 			case 0 -> "예약";
 			case 1 -> "취소";
 			case 2 -> "자동취소";
+			case 3 -> "관리자취소";
 			default -> "";
 		};
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
@@ -13,7 +13,12 @@ public interface LibraryHistoryRepository extends JpaRepository<LibraryHistory, 
 	Optional<LibraryHistory> findTopByUserIdAndDateBetweenOrderByDateDesc(
 		Long UserId,
 		LocalDateTime startOfDay,
-		LocalDateTime endOfDay);
+		LocalDateTime endOfDay
+	);
+
+	Optional<LibraryHistory> findTopByUserIdOrderByIdDesc(Long aptAccountId);
 
 	Slice<LibraryHistory> findByUserIdOrderByIdDesc(Long aptAccountId, Pageable pageable);
+
+	Slice<LibraryHistory> findAllByOrderByIdDesc(Pageable pageable);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -225,7 +225,7 @@ public class LibraryService {
 	}
 
 	@Transactional
-	public RsData<String> AdminCancel(AptAccount targetUser, Seat seat, Long libraryHistoryId) {
+	public RsData<String> adminCancel(AptAccount targetUser, Seat seat, Long libraryHistoryId) {
 		RsData<String> addressString = makeAddressToString(targetUser);
 		if (addressString.isFail()) {
 			return addressString;

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -220,7 +220,7 @@ public class LibraryService {
 		return RsData.of("S-1", "취소 가능한 자리입니다.", optSeat.get());
 	}
 
-	public AptAccount getTargetUser(Long libraryHistoryId) {
+	public AptAccount getTargetUserForAdminCancel(Long libraryHistoryId) {
 		return libraryHistoryRepository.findById(libraryHistoryId).get().getUser();
 	}
 

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
+import com.ll.townforest.boundedContext.apt.entity.AptAccountHouse;
+import com.ll.townforest.boundedContext.apt.repository.AptAccountHouseRepository;
 import com.ll.townforest.boundedContext.apt.repository.AptAccountRepository;
 import com.ll.townforest.boundedContext.apt.repository.AptRepository;
 import com.ll.townforest.boundedContext.library.entity.Library;
@@ -32,6 +34,7 @@ public class LibraryService {
 	private final LibraryHistoryRepository libraryHistoryRepository;
 	private final AptAccountRepository aptAccountRepository;
 	private final AptRepository aptRepository;
+	private final AptAccountHouseRepository aptAccountHouseRepository;
 
 	public List<Seat> findUseableList(Long libraryId) {
 		Optional<Library> optLibrary = libraryRepository.findById(libraryId);
@@ -46,6 +49,10 @@ public class LibraryService {
 
 		return libraryHistoryRepository
 			.findTopByUserIdAndDateBetweenOrderByDateDesc(aptAccountId, startOfDay, endOfDay);
+	}
+
+	private Optional<LibraryHistory> lastHistory(Long aptAccountId) {
+		return libraryHistoryRepository.findTopByUserIdOrderByIdDesc(aptAccountId);
 	}
 
 	public LibraryHistory usingHistory(Long aptAccountId) {
@@ -84,10 +91,16 @@ public class LibraryService {
 
 	@Transactional
 	public RsData<String> booking(AptAccount user, Seat seat, int selectedSeat) {
+		RsData<String> addressString = makeAddressToString(user);
+		if (addressString.isFail()) {
+			return addressString;
+		}
+
 		libraryHistoryRepository.save(LibraryHistory.builder()
 			.apart(aptRepository.findById(1L).orElse(null))
 			.library(libraryRepository.findById(1L).orElse(null))
 			.user(user)
+			.addressToString(addressString.getData())
 			.seat(seat)
 			.date(LocalDateTime.now())
 			.statusType(0)
@@ -98,6 +111,17 @@ public class LibraryService {
 			.build());
 
 		return RsData.of("S-1", "%03d번 자리를 예약했습니다.".formatted(selectedSeat));
+	}
+
+	private RsData<String> makeAddressToString(AptAccount user) {
+
+		AptAccountHouse aptAccountHouse = aptAccountHouseRepository.findByUserId(user.getId()).orElse(null);
+		if (aptAccountHouse == null) {
+			return RsData.of("F-3", "주소를 알 수 없는 계정입니다.");
+		}
+
+		return RsData.of("S-1", "주소를 문자열로 변환합니다.",
+			aptAccountHouse.getHouse().getDong() + "동 " + aptAccountHouse.getHouse().getHo() + "호");
 	}
 
 	public RsData<AptAccount> canCancel(Long aptAccountId) {
@@ -131,10 +155,16 @@ public class LibraryService {
 
 	@Transactional
 	public RsData<String> cancel(AptAccount user, Seat seat, int selectedSeat) {
+		RsData<String> addressString = makeAddressToString(user);
+		if (addressString.isFail()) {
+			return addressString;
+		}
+
 		libraryHistoryRepository.save(LibraryHistory.builder()
 			.apart(aptRepository.findById(1L).orElse(null))
 			.library(libraryRepository.findById(1L).orElse(null))
 			.user(user)
+			.addressToString(addressString.getData())
 			.seat(seat)
 			.date(LocalDateTime.now())
 			.statusType(1)
@@ -149,5 +179,73 @@ public class LibraryService {
 
 	public Slice<LibraryHistory> findHistories(Long aptAccountId, Pageable pageable) {
 		return libraryHistoryRepository.findByUserIdOrderByIdDesc(aptAccountId, pageable);
+	}
+
+	public Slice<LibraryHistory> findAllHistories(Pageable pageable) {
+		return libraryHistoryRepository.findAllByOrderByIdDesc(pageable);
+	}
+
+	public RsData<AptAccount> canAdminCancel(AptAccount user) {
+		if (user.getApt().getId() != 1) {
+			return RsData.of("F-1", "해당 아파트에 대한 권한이 없습니다.");
+		}
+
+		if (user.getAuthority() != 2) {
+			return RsData.of("F-2", "독서실 관리자만 가능한 동작입니다.");
+		}
+
+		return RsData.of("S-1", "취소 가능한 계정입니다.", user);
+	}
+
+	public RsData<Seat> canAdminCancel(Long libraryHistoryId) {
+		Optional<LibraryHistory> optLibraryHistory = libraryHistoryRepository.findById(libraryHistoryId);
+		if (optLibraryHistory.isEmpty()) {
+			return RsData.of("F-1", "존재하지 않는 히스토리입니다.");
+		}
+		LibraryHistory libraryHistory = optLibraryHistory.get();
+
+		Optional<Seat> optSeat = seatRepository.findBySeatNumber(libraryHistory.getSeat().getSeatNumber());
+		if (optSeat.isEmpty() || optSeat.get().getStatus() != 1) {
+			return RsData.of("F-1", "비어있는 자리입니다.");
+		}
+
+		Optional<LibraryHistory> lastHistoryOfTarget = lastHistory(libraryHistory.getUser().getId());
+		if (lastHistoryOfTarget.isEmpty()) {
+			return RsData.of("F-2", "대상자 이용 내역이 존재하지 않습니다.");
+		}
+		if (!lastHistoryOfTarget.get().equals(libraryHistory)) {
+			return RsData.of("F-3", "대상자의 마지막 이력이 아닙니다.");
+		}
+
+		return RsData.of("S-1", "취소 가능한 자리입니다.", optSeat.get());
+	}
+
+	public AptAccount getTargetUser(Long libraryHistoryId) {
+		return libraryHistoryRepository.findById(libraryHistoryId).get().getUser();
+	}
+
+	@Transactional
+	public RsData<String> AdminCancel(AptAccount targetUser, Seat seat, Long libraryHistoryId) {
+		RsData<String> addressString = makeAddressToString(targetUser);
+		if (addressString.isFail()) {
+			return addressString;
+		}
+
+		libraryHistoryRepository.save(LibraryHistory.builder()
+			.apart(aptRepository.findById(1L).orElse(null))
+			.library(libraryRepository.findById(1L).orElse(null))
+			.user(targetUser)
+			.addressToString(addressString.getData())
+			.seat(seat)
+			.date(LocalDateTime.now())
+			.statusType(3)
+			.build());
+
+		seatRepository.save(seat.toBuilder()
+			.status(0)
+			.build());
+
+		return RsData.of("S-1",
+			"%s님의 %03d번 자리 이용을 취소합니다.".formatted(targetUser.getAccount().getFullName(), seat.getSeatNumber()));
 	}
 }

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -10,35 +10,49 @@
 <main layout:fragment="main" class="flex flex-col">
     <!-- 자리 배치 표 -->
     <img src="/librarySeat.png" alt="자리 배치 표" class="mx-[5%]">
-    <!-- card ui, 이용내역 -->
+    <!-- card ui, 모든 독서실 히스토리 출력 -->
     <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl">
         <div class="card-body p-3">
             <h2 class="card-title">이용 현황</h2>
-            <P th:if="${histories.numberOfElements} == 0" class="text-center my-5">
-                독서실 이용 내역이 없습니다.
-            </P>
-            <div class="overflow-x-auto" th:if="${histories.numberOfElements} != 0">
-                <table class="table text-center">
-                    <!-- head -->
-                    <thead>
-                    <tr>
-                        <th>Date.</th>
-                        <th>User.</th>
-                        <th>Seat No.</th>
-                        <th>Status.</th>
-                    </tr>
-                    </thead>
-                    <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
-                    <tbody id="contentList">
-                    <tr th:each="history : ${histories}">
-                        <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
-                        <td th:text="${history.user.fullName}"></td>
-                        <td th:text="${history.seat.seatNumber}"></td>
-                        <td th:text="${history.getStatusTypeToString()}"></td>
-                    </tr>
-                    </tbody>
 
-                </table>
+            <P th:if="${histories.numberOfElements} == 0" class="text-center my-5">
+                독서실 이용 히스토리가 없습니다.
+            </P>
+            <div th:if="${histories.numberOfElements} != 0">
+                <div class="overflow-x-auto">
+                    <table class="table text-center">
+                        <!-- head -->
+                        <thead>
+                        <tr>
+                            <th>Date.</th>
+                            <th>User.</th>
+                            <th>Address.</th>
+                            <th>Seat No.</th>
+                            <th>Status.</th>
+                            <th></th>
+                        </tr>
+                        </thead>
+
+                        <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
+                        <tbody id="contentList">
+                        <!-- row 1 -->
+                        <tr th:each="history : ${histories}">
+                            <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
+                            <td th:text="${history.user.account.fullName}" style="min-width: 86px;"></td>
+                            <td th:text="${history.addressToString}"></td>
+                            <td th:text="${history.seat.seatNumber}"></td>
+                            <td th:text="${history.statusTypeToString}" style="min-width:80px; padding: 12px 0;"></td>
+                            <td th:if="${history.statusType} == 0" style="min-width:100px; padding: 12px 0;">
+                                <button th:onclick="submitAdminCancel([[${history.id}]])"
+                                        class="btn btn-info btn-sm text-white cancel-button">
+                                    취소하기
+                                </button>
+                            </td>
+                        </tr>
+                        </tbody>
+
+                    </table>
+                </div>
                 <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
                 <button id="more" class="btn btn-info btn-outline btn-sm w-full"
                         th:if="${histories.last} == false"
@@ -49,7 +63,7 @@
         </div>
     </div>
     <script>
-        const numRows = 5; // 한 번에 가져오고자 하는 로우의 개수
+        const numRows = 25; // 한 번에 가져오고자 하는 로우의 개수
         let currPage = 0; // 현재 페이지 카운터
 
         function loadHistories() {
@@ -58,7 +72,7 @@
             currPage++; // 페이지 카운터 증가
 
             $.ajax({
-                url: '/library/histories',
+                url: '/admin/library/histories',
                 type: 'POST',
                 data: {
                     page: currPage,
@@ -71,10 +85,21 @@
                     // 결과가 성공적으로 수신되면 테이블에 로우 추가
                     $.each(data.content, function (index, history) {
                         let newRow = `<tr>
-                        <td>${dateFormat(history.date)}</td>
-                        <td>${history.seat.seatNumber}</td>
-                        <td>${history.statusTypeToString}</td>
-                      </tr>`;
+                            <td>${dateFormat(history.date)}</td>
+                            <td style="min-width: 86px;">${history.user.account.fullName}</td>
+                            <td>${history.addressToString}</td>
+                            <td>${history.seat.seatNumber}</td>
+                            <td style="min-width:80px; padding: 12px 0;">${history.statusTypeToString}</td>`;
+                        if (history.statusType === 0) {
+                            newRow += `<td style="min-width:100px; padding: 12px 0;">
+                                <button onclick="submitAdminCancel(${history.id})"
+                                        class="btn btn-info btn-sm text-white cancel-button">
+                                    취소하기
+                                </button>
+                            </td>`;
+                        }
+                        newRow += `</tr>`;
+
                         $('#contentList').append(newRow);
                     });
                     if (data.last) {
@@ -87,18 +112,15 @@
             });
         }
 
-        function submitBooking(form) {
+        function submitAdminCancel(historyId) {
             let header = $("meta[name='_csrf_header']").attr('content');
             let token = $("meta[name='_csrf']").attr('content');
-            let selectedSeat = form.selectedSeat.value.slice(0, -1);
 
-            // AJAX 요청
             $.ajax({
+                url: '/admin/library/cancel',
                 type: 'POST',
-                url: form.action,
                 data: {
-                    _csrf: form._csrf.value,
-                    selectedSeat: selectedSeat
+                    libraryHistoryId: historyId * 1
                 },
                 beforeSend: function (xhr) {
                     xhr.setRequestHeader(header, token);
@@ -107,35 +129,8 @@
                     alert(result);
                     window.location.reload();
                 },
-                error: function (xhr, textStatus, errorThrown) {
-                    console.error('Error: ' + errorThrown);
-                    alert('Error: 예약에 실패했습니다.');
-                }
-            });
-        }
-
-        function submitCancel() {
-            let header = $("meta[name='_csrf_header']").attr('content');
-            let token = $("meta[name='_csrf']").attr('content');
-            let seatNumber = document.getElementById("usingSeatNum").innerText * 1;
-
-            // AJAX 요청
-            $.ajax({
-                type: 'POST',
-                url: '/library/cancel',
-                data: {
-                    seatNumber: seatNumber
-                },
-                beforeSend: function (xhr) {
-                    xhr.setRequestHeader(header, token);
-                },
-                success: function (result) {
-                    alert(result);
-                    window.location.reload();
-                },
-                error: function (xhr, textStatus, errorThrown) {
-                    console.error('Error: ' + errorThrown);
-                    alert('Error: 예약 취소에 실패했습니다.');
+                error: function (err) {
+                    console.log("Error fetching data:", err);
                 }
             });
         }

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -1,6 +1,6 @@
 <html layout:decorate="~{home/layout.html}">
 <head>
-    <title>독서실 이용</title>
+    <title>독서실 이용 현황</title>
     <script src="/js/dateUtil.js"></script>
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
     <meta name="_csrf" th:content="${_csrf.token}">
@@ -10,72 +10,35 @@
 <main layout:fragment="main" class="flex flex-col">
     <!-- 자리 배치 표 -->
     <img src="/librarySeat.png" alt="자리 배치 표" class="mx-[5%]">
-    <!-- card ui, 독서실 자리 예약 (로그인 유저가 미이용중일 때) -->
-    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl" th:if="${isUsing == null}">
-        <div class="card-body p-3">
-            <h2 class="card-title">독서실 자리 예약</h2>
-            <form th:action="|/library/booking|" method="POST" onsubmit="event.preventDefault(); submitBooking(this);">
-
-                <select class="select select-bordered w-full my-2" name="selectedSeat">
-                    <option disabled selected>예약 가능한 자리</option>
-                    <th:block th:each="seat : ${seats}">
-                        <option th:text="${#numbers.formatInteger(seat.seatNumber,3)} + '번'"></option>
-                    </th:block>
-                </select>
-
-                <div class="card-actions justify-end">
-                    <button class="btn btn-info btn-sm text-white">예약하기</button>
-                </div>
-            </form>
-        </div>
-    </div>
-    <!-- card ui, 독서실 이용중 예약한 자리 번호 (로그인 유저가 이용중일 때) -->
-    <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl" th:if="${isUsing != null}">
-        <div class="card-body p-3">
-            <h2 class="card-title">독서실 자리 예약</h2>
-            <p class="text-center my-2">
-                <b id="usingSeatNum" th:text="${#numbers.formatInteger(isUsing.seat.seatNumber,3)}"></b>번 자리를 이용중입니다.
-            </p>
-            <div class="card-actions justify-end">
-                <button class="btn btn-info btn-sm text-white"
-                        onclick="event.preventDefault(); submitCancel();">
-                    취소하기
-                </button>
-            </div>
-        </div>
-    </div>
     <!-- card ui, 이용내역 -->
     <div class="card bg-base-900 shadow-xl m-[5%] rounded-xl">
         <div class="card-body p-3">
-            <h2 class="card-title">이용 내역</h2>
-
+            <h2 class="card-title">이용 현황</h2>
             <P th:if="${histories.numberOfElements} == 0" class="text-center my-5">
                 독서실 이용 내역이 없습니다.
             </P>
-            <div th:if="${histories.numberOfElements} != 0">
-                <div class="overflow-x-auto">
-                    <table class="table text-center">
-                        <!-- head -->
-                        <thead>
-                        <tr>
-                            <th>Date.</th>
-                            <th>Seat No.</th>
-                            <th>Status.</th>
-                        </tr>
-                        </thead>
+            <div class="overflow-x-auto" th:if="${histories.numberOfElements} != 0">
+                <table class="table text-center">
+                    <!-- head -->
+                    <thead>
+                    <tr>
+                        <th>Date.</th>
+                        <th>User.</th>
+                        <th>Seat No.</th>
+                        <th>Status.</th>
+                    </tr>
+                    </thead>
+                    <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
+                    <tbody id="contentList">
+                    <tr th:each="history : ${histories}">
+                        <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
+                        <td th:text="${history.user.fullName}"></td>
+                        <td th:text="${history.seat.seatNumber}"></td>
+                        <td th:text="${history.getStatusTypeToString()}"></td>
+                    </tr>
+                    </tbody>
 
-                        <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
-                        <tbody id="contentList">
-                        <!-- row 1 -->
-                        <tr th:each="history : ${histories}">
-                            <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
-                            <td th:text="${history.seat.seatNumber}"></td>
-                            <td th:text="${history.statusTypeToString}" style="min-width:80px; padding: 12px 0;"></td>
-                        </tr>
-                        </tbody>
-
-                    </table>
-                </div>
+                </table>
                 <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
                 <button id="more" class="btn btn-info btn-outline btn-sm w-full"
                         th:if="${histories.last} == false"
@@ -110,7 +73,7 @@
                         let newRow = `<tr>
                         <td>${dateFormat(history.date)}</td>
                         <td>${history.seat.seatNumber}</td>
-                        <td style="min-width:80px; padding: 12px 0;">${history.statusTypeToString}</td>
+                        <td>${history.statusTypeToString}</td>
                       </tr>`;
                         $('#contentList').append(newRow);
                     });

--- a/src/main/resources/templates/admin/main.html
+++ b/src/main/resources/templates/admin/main.html
@@ -1,0 +1,94 @@
+<html layout:decorate="~{home/layout.html}">
+<head>
+    <title>관리자 메뉴</title>
+    <style>
+        button.btn.btn-outline.btn-primary {
+            width: 174px;
+            height: 80px;
+            border-radius: 15px;
+        }
+
+        h2 {
+            display: block;
+            font-size: 1.5em !important;
+            margin-top: 0.5em !important;
+            margin-bottom: 0.5em !important;
+            margin-left: 0.5em !important;
+            margin-right: 0 !important;
+            font-weight: bold !important;
+        }
+    </style>
+</head>
+<body>
+<!-- main -->
+<main layout:fragment="main">
+    <!-- 공지사항 -->
+    <div class="m-3" style="border: 1px solid #707070; border-radius: 15px;">
+        <h2>공지사항</h2>
+        <div class="overflow-x-auto">
+            <table class="table">
+                <!-- head -->
+                <thead>
+                <tr>
+                    <th></th>
+                    <th>Name</th>
+                </tr>
+                </thead>
+                <tbody>
+                <!-- row 1 -->
+                <tr>
+                    <th>1</th>
+                    <td>Cy Ganderton</td>
+                </tr>
+                <!-- row 2 -->
+                <tr class="hover">
+                    <th>2</th>
+                    <td>Hart Hagerty</td>
+                </tr>
+                <!-- row 3 -->
+                <tr>
+                    <th>3</th>
+                    <td>Brice Swyre</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <!-- 버튼메뉴 -->
+    <div class="flex justify-center flex-wrap gap-3">
+        <button id="gym"
+                class="btn btn-outline btn-primary">
+            헬스장 신청
+        </button>
+        <button id="library" onclick="javascript: window.location.href='/admin/library/histories';"
+                class="btn btn-outline btn-primary">
+            독서실 관리
+        </button>
+        <button id="my-vehicle"
+                class="btn btn-outline btn-primary">
+            차량 등록
+        </button>
+        <button id="repair"
+                class="btn btn-outline btn-primary">
+            시설 보수 신청
+        </button>
+        <button id="guest-house"
+                class="btn btn-outline btn-primary">
+            게스트하우스 신청
+        </button>
+        <button id="guest-vehicle"
+                class="btn btn-outline btn-primary">
+            방문차량 등록
+        </button>
+        <button id="mypage"
+                class="btn btn-outline btn-primary">
+            마이페이지
+        </button>
+        <button id="none"
+                class="btn btn-outline btn-primary"
+                style="visibility:hidden">
+        </button>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/main.html
+++ b/src/main/resources/templates/admin/main.html
@@ -1,6 +1,6 @@
 <html layout:decorate="~{home/layout.html}">
 <head>
-    <title>관리자 메뉴</title>
+    <title>관리자</title>
     <style>
         button.btn.btn-outline.btn-primary {
             width: 174px;


### PR DESCRIPTION
## Description
독서실 관리자가 전체 히스토리를 조회하고, 이용중인 자리 예약을 강제로 취소할 수 있습니다.

## Changes

- **boundedContext/home/controller/AdminController.java**
    - [x] showAdmin()
        - admin 메인 페이지로 연결합니다.
        - 관리자 권한이 있는 이용자만 주소창에 직접 ```/admin``` 입력하여 접근할 수 있습니다.
        - **현재 '독서실 관리'탭만 이름 변경 및 uri 연결 돼있습니다.** 관리자 페이지 만드신 후 연결 부탁드립니다!
    - [x] showLibraryHistories()
        - 독서실 히스토리 조회 페이지로 연결합니다.
        - 전체 관리자, 독서실 관리자 권한이 있는 이용자만 접근 허용합니다.
    - [x] libraryBookingCancel()
        - 로그인 이용자가 삭제할 수 있는 권한이 있는지, 취소할 수 있는 히스토리인지 검사합니다.
        - 히스토리의 유저를 통해 타겟 유저를 조회해 서비스의 adminCancel()함수를 호출합니다. 

- **boundedContext/library/service/LibraryService.java**
    - [x] makeAddressToString()
        - 이용자의 주소(동-호)를 문자열로 변환하는 함수
        - 독서실 히스토리에 저장할 때 이용합니다.
        - 독서실과 직접적인 연관이 없는 로직이기 때문에 **추후 AptAccountService로 이동시키고, 다른 히스토리 함수들에도 사용할 수 있으면 좋을것 같습니다.**
    - [x] getTargetUserForAdminCancel()
        - 히스토리의 주인인 AptAccount를 조회합니다. 
    - [x]  canAdminCancel()
        - '해당 아파트'의 '독서실 관리자'인지 검증합니다. 
        - 실제로 존재하는 히스토리인지 검증합니다.
        - 대상자의 마지막 히스토리가 맞는지 검증합니다.
        - 사용중인 자리가 맞는지 검증합니다.
    - [x] adminCancel()
        - '관리자취소' 히스토리를 추가합니다.
        - 해당 자리를 이용가능한 상태로 변경합니다.

- **resources/template/admin**
    - [x] main.html
    - [x] histories.html
        - [x] loadHistories()
            - 히스토리 더보기 버튼 동작입니다. (booking.html과 의미 동일)
        - [x] submitAdminCancel()
            -  관리자 권한으로 독서실 자리 이용을 취소시킵니다.


### ETC
원래 페이지 작성이랑 기능 구현을 따로 이슈로 나누려고 했는데
기존에 있던 booking.html을 복사하다보니., 기능 구현까지 한꺼번에 하게 돼버렸습니다.
양해 부탁드려요 💦

---
Close #48 
