### PR TITLE
Enhancement69/gym

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
@@ -21,10 +21,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.ll.townforest.base.rq.Rq;
+import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.gym.entity.GymHistory;
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
@@ -56,7 +58,7 @@ public class GymController {
 		model.addAttribute("user", user);
 
 		// 이용중인 이용권 정보
-		GymMembership gymMembership = gymService.getMembership(user);
+		GymMembership gymMembership = gymService.getMembershipByUser(user);
 		model.addAttribute("gymMembership", gymMembership);
 
 		// 시작일 전 일 경우, 시작이 며칠 남았는지
@@ -76,8 +78,55 @@ public class GymController {
 	}
 
 	@GetMapping("/pause")
-	public String pause() {
+	@PreAuthorize("isAuthenticated()")
+	public String showPause(Model model) {
+		AptAccount user = rq.getAptAccount();
+
+		if (user == null || !user.isStatus())
+			return rq.historyBack("승인된 아파트 주민만 이용할 수 있습니다.");
+
+		model.addAttribute("user", user);
+
+		GymMembership membership = gymService.getMembershipByUser(user);
+
+		if (membership == null)
+			return rq.historyBack("이용중인 이용권이 없습니다.");
+
+		if (membership.getStatus() == 0)
+			return rq.historyBack("시작일 전에는 일시정지가 불가능합니다.");
+
+		model.addAttribute("membership", membership);
+
+		// 이용권 총 며칠 남았는지
+		long afterDays = ChronoUnit.DAYS.between(LocalDate.now(), membership.getEndDate());
+		model.addAttribute("afterDays", afterDays);
+
 		return "gym/pause";
+	}
+
+	@PostMapping("/pause")
+	@PreAuthorize("isAuthenticated()")
+	public String pause(@RequestParam Long membershipId) {
+		AptAccount user = rq.getAptAccount();
+
+		if (user == null || !user.isStatus())
+			return rq.historyBack("승인된 아파트 주민만 이용할 수 있습니다.");
+
+		GymMembership membership = gymService.getMembershipByUser(user);
+		GymMembership pauseMembership = gymService.getMembershopByMembershipId(membershipId);
+
+		if (pauseMembership == null)
+			return rq.historyBack("정지하고자 하는 이용권이 없습니다.");
+
+		if (!membership.equals(pauseMembership))
+			return rq.historyBack("본인 이용권만 일시정지 가능합니다.");
+
+		if (membership.getStatus() == 2)
+			return rq.historyBack("이미 일시정지된 이용권입니다.");
+
+		RsData<GymMembership> result = gymService.pauseMembership(pauseMembership);
+
+		return rq.redirectWithMsg("/gym", result);
 	}
 
 	@GetMapping("/refund")
@@ -97,7 +146,7 @@ public class GymController {
 		model.addAttribute("user", user);
 
 		// 연장용 일 경우 startDate를 현제 가지고 있는 이용권의 종료일+1로 지정하기 위해 필요
-		GymMembership membership = gymService.getMembership(user);
+		GymMembership membership = gymService.getMembershipByUser(user);
 		model.addAttribute("membership", membership);
 
 		// 아파트 여러개라면 현재 로그인한 사용자가 속한 Gym ID를 넘긴다.
@@ -193,7 +242,7 @@ public class GymController {
 
 		// TODO : 결제방식 추가 시 수정 필요 / method를 받아서 넣어주기
 		if (isSuccess) {
-			GymMembership membership = gymService.getMembership(user);
+			GymMembership membership = gymService.getMembershipByUser(user);
 
 			if (membership == null)
 				gymService.create(user, startDate, ticketType, "카드");

--- a/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
@@ -129,6 +129,31 @@ public class GymController {
 		return rq.redirectWithMsg("/gym", result);
 	}
 
+	@PostMapping("/unpause")
+	@PreAuthorize("isAuthenticated()")
+	public String unPause(@RequestParam Long membershipId) {
+		AptAccount user = rq.getAptAccount();
+
+		if (user == null || !user.isStatus())
+			return rq.historyBack("승인된 아파트 주민만 이용할 수 있습니다.");
+
+		GymMembership membership = gymService.getMembershipByUser(user);
+		GymMembership pauseMembership = gymService.getMembershopByMembershipId(membershipId);
+
+		if (pauseMembership == null)
+			return rq.historyBack("정지를 풀고자 하는 이용권이 없습니다.");
+
+		if (!membership.equals(pauseMembership))
+			return rq.historyBack("본인 이용권만 일시정지 가능합니다.");
+
+		if (membership.getStatus() != 2)
+			return rq.historyBack("이미 일시정지가 풀린 이용권입니다.");
+
+		RsData<GymMembership> result = gymService.unPauseMembership(pauseMembership);
+
+		return rq.redirectWithMsg("/gym", result);
+	}
+
 	@GetMapping("/refund")
 	public String refund() {
 		return "gym/refund";

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -3,7 +3,6 @@ package com.ll.townforest.boundedContext.gym.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.ll.townforest.boundedContext.apt.entity.Apt;
@@ -40,7 +39,7 @@ public class GymHistory {
 	private Apt apt;
 	private LocalDate startDate;
 	private LocalDate endDate;
-	@CreatedDate
+
 	private LocalDateTime paymentDate;
 	private int price;
 	/*
@@ -67,4 +66,6 @@ public class GymHistory {
 	private LocalDate pauseDate;
 	// 일시정지 후 남은 날짜
 	private Integer remainingDay;
+	// 재시작일
+	private LocalDate restartDate;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -59,7 +59,7 @@ public class GymHistory {
 	1: 연장
 	2: 일시정지
 	3: 재시작
-	추가 예정	// TODO : 상태 고려
+	4. 만료
 	*/
 	private int status;
 

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -57,7 +57,14 @@ public class GymHistory {
 	상태
 	0: 결제
 	1: 연장
+	2: 일시정지
+	3: 재시작
 	추가 예정	// TODO : 상태 고려
 	*/
 	private int status;
+
+	// 일시정지 한 날
+	private LocalDate pauseDate;
+	// 일시정지 후 남은 날짜
+	private Integer remainingDate;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -66,5 +66,5 @@ public class GymHistory {
 	// 일시정지 한 날
 	private LocalDate pauseDate;
 	// 일시정지 후 남은 날짜
-	private Integer remainingDate;
+	private Integer remainingDay;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -48,7 +48,12 @@ public class GymMembership {
 	1: 이용중
 	2: 일시정지
 	3: 연장
-	추가 예정	// TODO : 상태 고려, 일시정지 기능 구현 시 일시정지날 기록용 변수 필요할 듯
+	4: 재시작
 	*/
 	private int status;
+
+	// 일시정지 한 날
+	private LocalDate pauseDate;
+	// 일시정지 후 남은 날짜
+	private Integer remainingDate;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -55,5 +55,5 @@ public class GymMembership {
 	// 일시정지 한 날
 	private LocalDate pauseDate;
 	// 일시정지 후 남은 날짜
-	private Integer remainingDate;
+	private Integer remainingDay;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -56,4 +56,6 @@ public class GymMembership {
 	private LocalDate pauseDate;
 	// 일시정지 후 남은 날짜
 	private Integer remainingDay;
+	// 재시작일
+	private LocalDate restartDate;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymHistoryRepository.java
@@ -1,9 +1,9 @@
 package com.ll.townforest.boundedContext.gym.repository;
 
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.ll.townforest.boundedContext.gym.entity.GymHistory;
 
 public interface GymHistoryRepository extends JpaRepository<GymHistory, Long> {

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
@@ -1,13 +1,17 @@
 package com.ll.townforest.boundedContext.gym.repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
 
 public interface GymMembershipRepository extends JpaRepository<GymMembership, Long> {
 	Optional<GymMembership> findByUserId(Long userId);
+
+	List<GymMembership> findAllByEndDateAndStatusNot(LocalDate endDate, int status);
+
+	List<GymMembership> findAllByStartDateAndStatus(LocalDate today, int status);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -3,11 +3,13 @@ package com.ll.townforest.boundedContext.gym.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,10 @@ import com.ll.townforest.boundedContext.gym.repository.GymRepository;
 import com.ll.townforest.boundedContext.gym.repository.GymTicketRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class GymService {
 	private final GymTicketRepository gymTicketRepository;
@@ -209,5 +213,56 @@ public class GymService {
 		gymHistoryRepository.save(tmp2);
 
 		return RsData.of("S-1", "일시정지 해제");
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 0 0 * * *")
+	public void delete() {
+		LocalDate endDate = LocalDate.now().minusDays(1);
+
+		// 일시정지 상태가 아니며, 어제 날짜가 끝인 이용권들을 찾는다.
+		// 오늘 날짜가 끝이라면, 끝나는날도 이용은 가능하니 어제 날짜로 찾기
+		// status가 2이면 일시정지 상태니까, 삭제하지 않는다.
+		List<GymMembership> list = gymMembershipRepository.findAllByEndDateAndStatusNot(endDate, 2);
+		gymMembershipRepository.deleteAll(list);
+
+		List<GymHistory> histories = new ArrayList<>();
+
+		// 누가 언제부터 언제까지 이용했던 헬스장 이용권 만료되었다 히스토리 남기기
+		for (GymMembership gymMembership : list) {
+			GymHistory tmp = GymHistory.builder()
+				.status(4) // 4는 만료
+				.gym(gymMembership.getGym())
+				.startDate(gymMembership.getStartDate())
+				.endDate(gymMembership.getEndDate())
+				.apt(gymMembership.getApt())
+				.user(gymMembership.getUser())
+				.build();
+
+			histories.add(tmp);
+		}
+
+		gymHistoryRepository.saveAll(histories);
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 0 0 * * *")
+	public void beginMembership() {
+		LocalDate today = LocalDate.now();
+
+		// 아직 이용권 대기 상태이며, 오늘 날짜가 시작인 이용권들을 찾는다.
+		// status를 0에서 1로 변경해준다(시작 대기 -> 시작)
+		// history는 변동 없음(이용 대기, 이용중 -> 0번 으로 결제로 표기)
+		List<GymMembership> searchlist = gymMembershipRepository.findAllByStartDateAndStatus(today, 0);
+
+		List<GymMembership> updatedList = new ArrayList<>();
+		for (GymMembership membership : searchlist) {
+			GymMembership tmp1 = membership.toBuilder()
+				.status(1)
+				.build();
+			updatedList.add(tmp1);
+		}
+
+		gymMembershipRepository.saveAll(updatedList);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -142,6 +142,7 @@ public class GymService {
 		return gymMembershipRepository.findById(membershipId).get();
 	}
 
+	@Transactional
 	public RsData<GymMembership> pauseMembership(GymMembership pauseMembership) {
 		LocalDate localDate = LocalDate.now();
 
@@ -177,6 +178,7 @@ public class GymService {
 
 	}
 
+	@Transactional
 	public RsData<GymMembership> unPauseMembership(GymMembership pauseMembership) {
 
 		LocalDate localDate = LocalDate.now();

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -197,6 +197,7 @@ public class GymService {
 			.pauseDate(null)
 			.remainingDay(null)
 			.endDate(updatedEndDate)
+			.restartDate(localDate)
 			.build();
 
 		gymMembershipRepository.save(tmp);
@@ -208,6 +209,7 @@ public class GymService {
 			.user(tmp.getUser())
 			.startDate(tmp.getStartDate())
 			.endDate(tmp.getEndDate())
+			.restartDate(localDate)
 			.build();
 
 		gymHistoryRepository.save(tmp2);

--- a/src/main/resources/templates/gym/gym.html
+++ b/src/main/resources/templates/gym/gym.html
@@ -56,7 +56,7 @@
                     <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
                     <div class="flex wrap items-center gap-2">
                         <p>남은일자 : </p>
-                        <p th:text="${gymMembership.remainingDate +'일'}"></p>
+                        <p th:text="${gymMembership.remainingDay +'일'}"></p>
                     </div>
                 </div>
                 <div class="flex wrap items-center gap-2">
@@ -66,7 +66,8 @@
                         <p th:if="${gymMembership.status==0}"> 이용 대기중</p>
                         <p th:if="${gymMembership.status==1}"> 이용 중</p>
                         <p th:if="${gymMembership.status==2}"> 일시정지</p>
-                        <p th:if="${gymMembership.status==3}"> 재시작</p>
+                        <p th:if="${gymMembership.status==3}"> 연장</p>
+                        <p th:if="${gymMembership.status==4}"> 재시작</p>
                     </div>
                 </div>
             </th:block>
@@ -91,10 +92,15 @@
                     th:if="${gymMembership.status !=2 and gymMembership.status !=0}"
                     onclick="javascript: window.location.href='/gym/pause';">일시정지
             </button>
-            <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
-                    th:if="${gymMembership.status ==2}"
-                    onclick="javascript: window.location.href='/gym/pause';">일시정지 해제
-            </button>
+            <form th:action="@{/gym/unpause}" method="POST" class="w-full">
+                <input type="hidden" name="membershipId" th:value="${gymMembership.id}"/>
+                <div class="w-full px-0.1 flex flex-col">
+                    <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
+                            th:if="${gymMembership.status ==2}"
+                            onclick="return confirm('일시정지를 해제 하시겠습니까?')">일시정지 해제
+                    </button>
+                </div>
+            </form>
             <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
                     onclick="javascript: window.location.href='/gym/refund';">환불신청
             </button>

--- a/src/main/resources/templates/gym/gym.html
+++ b/src/main/resources/templates/gym/gym.html
@@ -8,8 +8,8 @@
         <div class="card-body bg-base-100 shadow-xl m-2">
             <th:block th:if="${gymMembership != null}">
                 <div class="flex gap-2 items-center">
-                    <i class="fa-solid fa-ticket" style="color: #91c0fd;"></i>
-                    <h2 class="card-title">이용권 내역</h2>
+                    <i class="fa-regular fa-calendar-days" style="color: #91c0fd;"></i>
+                    <h2 class="card-title">이용권 정보</h2>
                 </div>
                 <div class="flex items-center gap-2">
                     <i class="fa-solid fa-user" style="color: #91c0fd;"></i>
@@ -18,14 +18,10 @@
                         <p>님</p>
                     </div>
                 </div>
-                <div class="flex wrap items-center gap-2 mt-2">
-                    <i class="fa-regular fa-calendar-days" style="color: #91c0fd;"></i>
-                    <p class="font-bold">이용권 정보</p>
-                </div>
                 <div class="flex wrap items-center gap-2">
                     <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
                     <div class="flex gap-2">
-                        <p th:if="${gymMembership.status==1}">결제일 : </p>
+                        <p th:if="${gymMembership.status!=3}">결제일 : </p>
                         <p th:if="${gymMembership.status==3}">연장일 : </p>
                         <p th:text="${#temporals.format(gymMembership.paymentDate, 'yy-MM-dd EEEEE요일')}"></p>
                     </div>
@@ -37,22 +33,30 @@
                         <p th:if="${gymMembership.status==0}"
                            th:text="|${#temporals.format(gymMembership.startDate, 'yy-MM-dd EEEEE요일')}|"></p>
                         <p th:if="${gymMembership.status==0}" class="font-bold"
-                           th:text="|${'(D+' + beforeDays + ')'}|"></p>
+                           th:text="|${'(D-' + beforeDays + ')'}|"></p>
 
-                        <p th:if="${gymMembership.status==1 or gymMembership.status==3}"
+                        <p th:if="${gymMembership.status!=0}"
                            th:text="${#temporals.format(gymMembership.startDate, 'yy-MM-dd EEEEE요일')}"></p>
                     </div>
                 </div>
                 <div class="flex wrap items-center gap-2">
                     <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
                     <div class="flex gap-2">
-                        <p>종료일 : </p>
-                        <p th:if="${gymMembership.status==0}"
+                        <p th:if="${gymMembership.status!=2}">종료일 : </p>
+                        <p th:if="${gymMembership.status!=2}"
                            th:text="${#temporals.format(gymMembership.endDate, 'yy-MM-dd EEEEE요일')}"></p>
-                        <p th:if="${gymMembership.status==1 or gymMembership.status==3}"
-                           th:text="|${#temporals.format(gymMembership.endDate, 'yy-MM-dd EEEEE요일')}|"></p>
-                        <p th:if="${gymMembership.status==1 or gymMembership.status==3}" class="font-bold"
+                        <p th:if="${gymMembership.status!=2}" class="font-bold"
                            th:text="|${'(D-' + afterDays + ')'}|"></p>
+                        <p th:if="${gymMembership.status==2}">일시정지일 : </p>
+                        <p th:if="${gymMembership.status==2}"
+                           th:text="${#temporals.format(gymMembership.pauseDate, 'yy-MM-dd EEEEE요일')}"></p>
+                    </div>
+                </div>
+                <div class="flex wrap items-center gap-2" th:if="${gymMembership.status==2}">
+                    <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
+                    <div class="flex wrap items-center gap-2">
+                        <p>남은일자 : </p>
+                        <p th:text="${gymMembership.remainingDate +'일'}"></p>
                     </div>
                 </div>
                 <div class="flex wrap items-center gap-2">
@@ -60,7 +64,9 @@
                     <div class="flex wrap items-center gap-2">
                         <p>상태 : </p>
                         <p th:if="${gymMembership.status==0}"> 이용 대기중</p>
-                        <p th:if="${gymMembership.status==1 or gymMembership.status==3}"> 이용 중</p>
+                        <p th:if="${gymMembership.status==1}"> 이용 중</p>
+                        <p th:if="${gymMembership.status==2}"> 일시정지</p>
+                        <p th:if="${gymMembership.status==3}"> 재시작</p>
                     </div>
                 </div>
             </th:block>
@@ -82,7 +88,12 @@
                     onclick="javascript: window.location.href='/gym/register';">연장신청
             </button>
             <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
+                    th:if="${gymMembership.status !=2 and gymMembership.status !=0}"
                     onclick="javascript: window.location.href='/gym/pause';">일시정지
+            </button>
+            <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
+                    th:if="${gymMembership.status ==2}"
+                    onclick="javascript: window.location.href='/gym/pause';">일시정지 해제
             </button>
             <button class="btn shadow-xl m-2" style="background-color: #91c0fd;"
                     onclick="javascript: window.location.href='/gym/refund';">환불신청

--- a/src/main/resources/templates/gym/gym.html
+++ b/src/main/resources/templates/gym/gym.html
@@ -39,6 +39,13 @@
                            th:text="${#temporals.format(gymMembership.startDate, 'yy-MM-dd EEEEE요일')}"></p>
                     </div>
                 </div>
+                <div class="flex wrap items-center gap-2" th:if="${gymMembership.status==4}">
+                    <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
+                    <div class="flex gap-2">
+                        <p>재시작일 : </p>
+                        <p th:text="|${#temporals.format(gymMembership.restartDate, 'yy-MM-dd EEEEE요일')}|"></p>
+                    </div>
+                </div>
                 <div class="flex wrap items-center gap-2">
                     <i class="fa-regular fa-circle-check" style="color: #91c0fd;"></i>
                     <div class="flex gap-2">

--- a/src/main/resources/templates/gym/history.html
+++ b/src/main/resources/templates/gym/history.html
@@ -22,8 +22,8 @@
                             <tr class="text-center">
                                 <th>순번</th>
                                 <th>결제일자</th>
-                                <th>시작날짜</th>
-                                <th>종료일자</th>
+                                <th>시작일</th>
+                                <th>종료일(일시정지일)</th>
                                 <th>결제금액</th>
                                 <th>비고</th>
                             </tr>
@@ -36,11 +36,20 @@
                                     style="min-width:40px; padding: 12px 0;"></td>
                                 <td th:text="${#temporals.format(gymHistory.startDate, 'yy-MM-dd')}"
                                     style="min-width:40px; padding: 12px 0;"></td>
-                                <td th:text="${#temporals.format(gymHistory.endDate, 'yy-MM-dd')}"
+                                <td th:if="${gymHistory.status ==2}"
+                                    th:text="${#temporals.format(gymHistory.pauseDate, 'yy-MM-dd')}"
                                     style="min-width:40px; padding: 12px 0;"></td>
-                                <td th:text="${#numbers.formatInteger(gymHistory.price, 3, 'COMMA') + '원'}"></td>
+                                <td th:if="${gymHistory.status !=2}"
+                                    th:text="${#temporals.format(gymHistory.endDate, 'yy-MM-dd')}"
+                                    style="min-width:40px; padding: 12px 0;"></td>
+                                <td th:if="${gymHistory.price !=null}"
+                                    th:text="${#numbers.formatInteger(gymHistory.price, 3, 'COMMA') + '원'}"></td>
+                                <td th:if="${gymHistory.price ==null}">-</td>
                                 <td th:if="${gymHistory.status==0}" style="min-width:40px; padding: 12px 0;">결제</td>
                                 <td th:if="${gymHistory.status==1}" style="min-width:40px; padding: 12px 0;">연장</td>
+                                <td th:if="${gymHistory.status==2}" style="min-width:40px; padding: 12px 0;">일시정지</td>
+                                <td th:if="${gymHistory.status==3}" style="min-width:40px; padding: 12px 0;">재시작</td>
+                                <td th:if="${gymHistory.status==4}" style="min-width:40px; padding: 12px 0;">만료</td>
                             </tr>
                             </tbody>
                         </table>

--- a/src/main/resources/templates/gym/history.html
+++ b/src/main/resources/templates/gym/history.html
@@ -11,7 +11,7 @@
         <div class="text-center flex flex-col wrap gap-2">
             <div class="flex gap-2 justify-center items-center">
                 <i class="fa-solid fa-comments-dollar" style="color: #70a5ff;"></i>
-                <p class="font-bold">결제 내역</p>
+                <p class="font-bold">이용 내역</p>
             </div>
             <th:block th:if="${paging.totalElements !=0}">
                 <div class="overflow-x-auto mt-4">
@@ -22,7 +22,7 @@
                             <tr class="text-center">
                                 <th>순번</th>
                                 <th>결제일자</th>
-                                <th>시작일</th>
+                                <th>시작일(재시작일)</th>
                                 <th>종료일(일시정지일)</th>
                                 <th>결제금액</th>
                                 <th>비고</th>
@@ -32,7 +32,11 @@
                             <tr class="text-center" th:each="gymHistory, loop : ${paging}">
                                 <!-- 1번 ~ 증가하는 식으로 순번 표시 -->
                                 <td th:text="${(paging.number * paging.size) + loop.index +1}">
-                                <td th:text="${#temporals.format(gymHistory.paymentDate, 'yy-MM-dd')}"
+                                <td th:if="${gymHistory.paymentDate ==null}" style="min-width:40px; padding: 12px 0;">
+                                    -
+                                </td>
+                                <td th:if="${gymHistory.paymentDate !=null}"
+                                    th:text="${#temporals.format(gymHistory.paymentDate, 'yy-MM-dd')}"
                                     style="min-width:40px; padding: 12px 0;"></td>
                                 <td th:text="${#temporals.format(gymHistory.startDate, 'yy-MM-dd')}"
                                     style="min-width:40px; padding: 12px 0;"></td>

--- a/src/main/resources/templates/gym/pause.html
+++ b/src/main/resources/templates/gym/pause.html
@@ -5,14 +5,35 @@
 </head>
 
 <body>
-
-<main layout:fragment="main">
-    <div class="flex flex-col items-center justify-center h-screen">
-        <div class="text-center flex wrap items-center gap-2">
-            <i class="fa-regular fa-face-grin-beam-sweat"></i>
-            <p>일시정지 기능은 현재 준비중입니다</p>
+<main layout:fragment="main" class="flex h-screen items-center">
+    <div class="w-full px-4 flex flex-col items-center">
+        <div class="card-body bg-base-100 shadow-xl m-2">
+            <form method="POST" th:action>
+                <input type="hidden" name="membershipId" th:value="${membership.id}">
+                <div class="flex gap-2 justify-center">
+                    <i class="fa-solid fa-circle-pause text-[3rem]" style="color: #7aabff;"></i>
+                    <h2 class="card-title">일시정지 안내</h2>
+                </div>
+                <div class="flex items-center gap-2 mt-8">
+                    <i class="fa-solid fa-user" style="color: #91c0fd;"></i>
+                    <div class="flex items-center">
+                        <p class="font-bold" th:text="${user.account.fullName}"></p>
+                        <p>님</p>
+                    </div>
+                </div>
+                <div class="mt-5">이용권 일시정지시 금일부터 이용이 제한됩니다.</div>
+                <div class="flex mt-5">
+                    <div>회원님의 남은 일수는</div>
+                    <div class="font-bold" th:text="${afterDays}"></div>
+                    <div>일입니다.</div>
+                </div>
+                <button class="btn btn-primary w-full mt-5" onclick="return confirm('일시정지 하시겠습니까?')">
+                    <i class="fa-regular fa-circle-pause" style="color: #73a1f7;"></i>
+                    일시정지하기
+                </button>
+            </form>
         </div>
-        <div class="flex gap-2 mt-2">
+        <div class="flex gap-2 mt-5">
             <div class="btn btn-primary" onclick="javascript: window.location.href='/';">
                 홈으로
             </div>

--- a/src/test/java/com/ll/townforest/boundedContext/gym/controller/GymControllerTest.java
+++ b/src/test/java/com/ll/townforest/boundedContext/gym/controller/GymControllerTest.java
@@ -1,0 +1,106 @@
+package com.ll.townforest.boundedContext.gym.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.townforest.boundedContext.gym.service.GymService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class GymControllerTest {
+	@Autowired
+	private MockMvc mvc;
+	@Autowired
+	private GymService gymService;
+
+	@Test
+	@WithUserDetails("yujin11006")
+	@DisplayName("성공 - 이용권 있는 회원의 일시정지 페이지 접속")
+	void t001() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(get("/gym/pause"))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(GymController.class))
+			.andExpect(handler().methodName("showPause"))
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(view().name("gym/pause"));
+	}
+
+	@Test
+	@WithUserDetails("puar12")
+	@DisplayName("승인되지 않은 회원의 일시정지 페이지 접속시 실패")
+	void t002() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(get("/gym/pause"))
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(GymController.class))
+			.andExpect(handler().methodName("showPause"))
+			.andExpect(status().is4xxClientError());
+	}
+
+	@Test
+	@WithUserDetails("yujin11006")
+	@DisplayName("이용권 일시정지 시도 - 성공")
+	void t003() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/gym/pause")
+				.with(csrf())
+				.param("membershipId", "1")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(handler().handlerType(GymController.class))
+			.andExpect(handler().methodName("pause"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("/gym**"));
+	}
+
+	@Test
+	@WithUserDetails("yujin11006")
+	@DisplayName("이용권 일시정지 후 일시정지 풀기 - 성공")
+	void t004() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(post("/gym/pause")
+				.with(csrf())
+				.param("membershipId", "1")
+			)
+			.andDo(print());
+
+		ResultActions resultActions2 = mvc
+			.perform(post("/gym/unpause")
+				.with(csrf())
+				.param("membershipId", "1")
+			)
+			.andDo(print());
+
+		resultActions2
+			.andExpect(handler().handlerType(GymController.class))
+			.andExpect(handler().methodName("unPause"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("/gym**"));
+	}
+
+}

--- a/src/test/java/com/ll/townforest/boundedContext/gym/service/GymServiceTest.java
+++ b/src/test/java/com/ll/townforest/boundedContext/gym/service/GymServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.townforest.base.rq.Rq;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
-import com.ll.townforest.boundedContext.gym.entity.GymHistory;
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
 import com.ll.townforest.boundedContext.gym.repository.GymHistoryRepository;
 
@@ -33,22 +32,6 @@ public class GymServiceTest {
 	private GymHistoryRepository gymHistoryRepository;
 	@Autowired
 	private Rq rq;
-
-	@Test
-	@DisplayName("이용권 결제 시 history 자동 생성")
-	@WithUserDetails("yujin11006")
-	void t001() throws Exception {
-
-		AptAccount aptAccount = rq.getAptAccount();
-
-		gymService.create(aptAccount, LocalDate.now(), 3, "카드");
-
-		// 51번까지 테스트 history
-		GymHistory gymHistory = gymHistoryRepository.findById(52L).orElse(null);
-
-		// 52번 history 생성 검사
-		assertThat(gymHistory).isNotNull();
-	}
 
 	@Test
 	@DisplayName("이용권 연장(추가결제) 시 이용정보 변경 테스트")

--- a/src/test/java/com/ll/townforest/boundedContext/gym/service/GymServiceTest.java
+++ b/src/test/java/com/ll/townforest/boundedContext/gym/service/GymServiceTest.java
@@ -57,7 +57,7 @@ public class GymServiceTest {
 
 		AptAccount aptAccount = rq.getAptAccount();
 
-		GymMembership gymMembership = gymService.getMembership(aptAccount);
+		GymMembership gymMembership = gymService.getMembershipByUser(aptAccount);
 
 		gymService.update(aptAccount, LocalDate.now(), LocalDate.now(), 1, "카드");
 


### PR DESCRIPTION
## Description
- 매일 12시 이용권 삭제 처리 / 이용 대기중인 이용권 시작 처리 스케줄러
- 이용권 일시정지/해제 기능 구현
<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- **gym/controller/GymController.java**
    - [x] getMembership -> getMembershipByUser
        - 메서드명을 뭐에 의해 얻어오는지 명확하게 했습니당
    - [x] showPause / pause / unpause
       - 일시정지 페이지를 보여줍니다.
       - 일시정지 시 유의사항 "오늘부터 정지" 안내와 일시정지 할 지 물어보는 페이지로 연결됩니다.
       - unpause : 별도 페이지를 만들지 않고 버튼 누르면 바로 POST 요청을 받아 처리합니다.
     - [x] **gym/entity/GymHistory.java**
       - 일시정지 및 재시작 날짜 저장하는 속성을 추가하였습니다.
       - 결제일은 원래 history 생성 시 저장되도록 했는데, 일시정지나 재시작의 경우 결제가 없기에 @CreateDate 어노테이션을 삭제하였습니다.
     - [x] HTML 수정사항 : 타임리프 조건문 추가하여 일시정지/재시작 이라면 다르게 보이게끔 수정했습니다.
       - 일시정지 / 재시작 : gym 메인에서 일시정지/재시작 상태, 재시작일 경우 재시작일 보여지게 등  
       - 개인별 history 보는 페이지에서도 재시작/일시정지 보이게 수정했습니다.

### ETC
- 테스트케이스는 보완 하여 추후 추가하겠습니다.
- 월요일에 관리자 페이지 나머지 기능 2개 마무리 하는데로 나머지 기능 도와드리도록 하겠습니다!
- 엔티티 속성 추가해가지고 혹시 오류나면 DB삭제 후 재생성 부탁드릴게영

---
Close #69 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->