### PR TITLE
Enhancement79/library admin

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -1,10 +1,12 @@
 package com.ll.townforest.boundedContext.home.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -55,7 +57,9 @@ public class AdminController {
 	// 독서실 관리자 페이지 시작
 	@GetMapping("/library/histories")
 	@PreAuthorize("isAuthenticated()")
-	public String showLibraryHistories(Model model, @RequestParam(defaultValue = "0") int page) {
+	public String showLibraryHistories(
+		Model model,
+		@RequestParam(defaultValue = "0") int page) {
 		if (!rq.isAdmin()) {
 			return rq.historyBack("관리자 전용 페이지입니다.");
 		}
@@ -67,6 +71,22 @@ public class AdminController {
 		Page<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(page, 25));
 		model.addAttribute("histories", histories);
 		return "admin/library/histories";
+	}
+
+	@PostMapping("/library/histories")
+	@PreAuthorize("isAuthenticated()")
+	@ResponseBody
+	public Page<LibraryHistory> histories(@RequestParam int page,
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate searchDate) {
+		return libraryService.findAllHistoriesByDate(searchDate, PageRequest.of(page, 25));
+	}
+
+	@PostMapping("/library/histories/all")
+	@PreAuthorize("isAuthenticated()")
+	@ResponseBody
+	public Page<LibraryHistory> histories(@RequestParam int page) {
+
+		return libraryService.findAllHistories(PageRequest.of(page, 25));
 	}
 
 	@PostMapping("/library/cancel")

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -56,7 +55,7 @@ public class AdminController {
 	// 독서실 관리자 페이지 시작
 	@GetMapping("/library/histories")
 	@PreAuthorize("isAuthenticated()")
-	public String showLibraryHistories(Model model) {
+	public String showLibraryHistories(Model model, @RequestParam(defaultValue = "0") int page) {
 		if (!rq.isAdmin()) {
 			return rq.historyBack("관리자 전용 페이지입니다.");
 		}
@@ -65,19 +64,14 @@ public class AdminController {
 			return rq.historyBack("독서실 관리 권한이 없습니다.");
 		}
 
-		Slice<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(0, 25));
+		Page<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(page, 25));
 		model.addAttribute("histories", histories);
 		return "admin/library/histories";
 	}
 
-	@PostMapping("/library/histories")
-	@ResponseBody
-	public Slice<LibraryHistory> libraryHistories(@RequestParam int page, @RequestParam int size) {
-		return libraryService.findAllHistories(PageRequest.of(page, size));
-	}
-
 	@PostMapping("/library/cancel")
 	@ResponseBody
+	@PreAuthorize("isAuthenticated()")
 	public String libraryBookingCancel(@RequestParam Long libraryHistoryId) {
 		RsData<AptAccount> canCancelUser = libraryService.canAdminCancel(rq.getAptAccount());
 		if (canCancelUser.isFail()) {

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -57,9 +57,7 @@ public class AdminController {
 	// 독서실 관리자 페이지 시작
 	@GetMapping("/library/histories")
 	@PreAuthorize("isAuthenticated()")
-	public String showLibraryHistories(
-		Model model,
-		@RequestParam(defaultValue = "0") int page) {
+	public String showLibraryHistories() {
 		if (!rq.isAdmin()) {
 			return rq.historyBack("관리자 전용 페이지입니다.");
 		}
@@ -68,8 +66,6 @@ public class AdminController {
 			return rq.historyBack("독서실 관리 권한이 없습니다.");
 		}
 
-		Page<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(page, 25));
-		model.addAttribute("histories", histories);
 		return "admin/library/histories";
 	}
 

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -47,8 +47,8 @@ public class AdminController {
 	@GetMapping("")
 	@PreAuthorize("isAuthenticated()")
 	public String showAdmin() {
-		if (rq.getAptAccount().getAuthority() == 0) {
-			return "redirect:/";
+		if (!rq.isAdmin()) {
+			return rq.historyBack("관리자 전용 페이지입니다.");
 		}
 		return "admin/main";
 	}
@@ -57,12 +57,12 @@ public class AdminController {
 	@GetMapping("/library/histories")
 	@PreAuthorize("isAuthenticated()")
 	public String showLibraryHistories(Model model) {
-		if (rq.getAptAccount().getAuthority() == 0) {
-			return "redirect:/";
+		if (!rq.isAdmin()) {
+			return rq.historyBack("관리자 전용 페이지입니다.");
 		}
 
-		if (rq.getAptAccount().getAuthority() == 3) {
-			return "redirect:/admin";
+		if (rq.isGymAdmin()) {
+			return rq.historyBack("독서실 관리 권한이 없습니다.");
 		}
 
 		Slice<LibraryHistory> histories = libraryService.findAllHistories(PageRequest.of(0, 25));
@@ -160,7 +160,7 @@ public class AdminController {
 		@RequestParam(defaultValue = "1") int tab
 	) {
 		if (rq.getAptAccount().getAuthority() != 1) {
-			return "redirect:/admin";
+			return rq.historyBack("차량 관리 권한이 없습니다.");
 		}
 
 		Page<GuestVehicleHistory> vehicles = vehicleService.findGuestByTab(page, tab);

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
@@ -3,6 +3,7 @@ package com.ll.townforest.boundedContext.library.repository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,7 +21,7 @@ public interface LibraryHistoryRepository extends JpaRepository<LibraryHistory, 
 
 	Slice<LibraryHistory> findByUserIdOrderByIdDesc(Long aptAccountId, Pageable pageable);
 
-	Slice<LibraryHistory> findAllByOrderByIdDesc(Pageable pageable);
+	Page<LibraryHistory> findAllByOrderByIdDesc(Pageable pageable);
 
 	Optional<LibraryHistory> findTopBySeatIdAndDateBetween(Long id, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/repository/LibraryHistoryRepository.java
@@ -23,5 +23,8 @@ public interface LibraryHistoryRepository extends JpaRepository<LibraryHistory, 
 
 	Page<LibraryHistory> findAllByOrderByIdDesc(Pageable pageable);
 
+	Page<LibraryHistory> findByDateBetweenOrderByIdDesc(LocalDateTime startOfDay, LocalDateTime endOfDay,
+		Pageable pageable);
+
 	Optional<LibraryHistory> findTopBySeatIdAndDateBetween(Long id, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -1,5 +1,6 @@
 package com.ll.townforest.boundedContext.library.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -185,6 +186,13 @@ public class LibraryService {
 
 	public Page<LibraryHistory> findAllHistories(Pageable pageable) {
 		return libraryHistoryRepository.findAllByOrderByIdDesc(pageable);
+	}
+
+	public Page<LibraryHistory> findAllHistoriesByDate(LocalDate searchDate, Pageable pageable) {
+		LocalDateTime startOfDay = searchDate.atStartOfDay();
+		LocalDateTime endOfDay = startOfDay.plusDays(1).minusSeconds(1);
+
+		return libraryHistoryRepository.findByDateBetweenOrderByIdDesc(startOfDay, endOfDay, pageable);
 	}
 
 	public RsData<AptAccount> canAdminCancel(AptAccount user) {

--- a/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/library/service/LibraryService.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -182,7 +183,7 @@ public class LibraryService {
 		return libraryHistoryRepository.findByUserIdOrderByIdDesc(aptAccountId, pageable);
 	}
 
-	public Slice<LibraryHistory> findAllHistories(Pageable pageable) {
+	public Page<LibraryHistory> findAllHistories(Pageable pageable) {
 		return libraryHistoryRepository.findAllByOrderByIdDesc(pageable);
 	}
 

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -53,65 +53,37 @@
 
                     </table>
                 </div>
-                <!-- 남은 리스트가 없다면 더보기 버튼 보이지 않도록 변경하기 -->
-                <button id="more" class="btn btn-info btn-outline btn-sm w-full"
-                        th:if="${histories.last} == false"
-                        onclick="event.preventDefault(); loadHistories()">
-                    더보기
-                </button>
+
+                <!-- 넘버링 페이지 -->
+                <div class="btn-group flex justify-center mt-7" th:if="${!histories.isEmpty()}">
+                    <div class="btn" th:classappend="${histories.number == 0} ? 'btn-disabled' : ''"
+                         th:attr="onclick='window.location.href=\'?page=0&size=25\''">
+                        &laquo;
+                    </div>
+                    <div th:attr="onclick='window.location.href=\'?page=' + (${histories.number - 1}) + '&size=25\''"
+                         class="btn" th:classappend="${!histories.hasPrevious} ? 'btn-disabled' : ''">
+                        이전
+                    </div>
+                    <div class="btn" th:each="page: ${#numbers.sequence(0, histories.totalPages - 1)}"
+                         th:classappend="${histories.number == page} ? 'btn-active' : ''"
+                         th:if="${page >= histories.number - 1 and page <= histories.number + 2}"
+                         th:attr="onclick='window.location.href=\'?page=' + (${page}) + '&size=25\''"
+                         th:text="${page+1}">
+                    </div>
+                    <div class="btn" th:classappend="${!histories.hasNext} ? 'btn-disabled' :''"
+                         th:attr="onclick='window.location.href=\'?page=' + (${histories.number + 1}) + '&size=25\''">
+                        다음
+                    </div>
+                    <div th:attr="onclick='window.location.href=\'?page=' + (${histories.totalPages - 1}) + '&size=25\''"
+                         class="btn"
+                         th:classappend="${histories.number == histories.totalPages - 1} ? 'btn-disabled' : ''">
+                        &raquo;
+                    </div>
+                </div>
             </div>
         </div>
     </div>
     <script>
-        const numRows = 25; // 한 번에 가져오고자 하는 로우의 개수
-        let currPage = 0; // 현재 페이지 카운터
-
-        function loadHistories() {
-            let header = $("meta[name='_csrf_header']").attr('content');
-            let token = $("meta[name='_csrf']").attr('content');
-            currPage++; // 페이지 카운터 증가
-
-            $.ajax({
-                url: '/admin/library/histories',
-                type: 'POST',
-                data: {
-                    page: currPage,
-                    size: numRows
-                },
-                beforeSend: function (xhr) {
-                    xhr.setRequestHeader(header, token);
-                },
-                success: function (data) {
-                    // 결과가 성공적으로 수신되면 테이블에 로우 추가
-                    $.each(data.content, function (index, history) {
-                        let newRow = `<tr>
-                            <td>${dateFormat(history.date)}</td>
-                            <td style="min-width: 86px;">${history.user.account.fullName}</td>
-                            <td>${history.addressToString}</td>
-                            <td>${history.seat.seatNumber}</td>
-                            <td style="min-width:80px; padding: 12px 0;">${history.statusTypeToString}</td>`;
-                        if (history.statusType === 0) {
-                            newRow += `<td style="min-width:100px; padding: 12px 0;">
-                                <button onclick="submitAdminCancel(${history.id})"
-                                        class="btn btn-info btn-sm text-white cancel-button">
-                                    취소하기
-                                </button>
-                            </td>`;
-                        }
-                        newRow += `</tr>`;
-
-                        $('#contentList').append(newRow);
-                    });
-                    if (data.last) {
-                        $('#more').addClass("hidden");
-                    }
-                },
-                error: function (err) {
-                    console.log("Error fetching data:", err);
-                }
-            });
-        }
-
         function submitAdminCancel(historyId) {
             let header = $("meta[name='_csrf_header']").attr('content');
             let token = $("meta[name='_csrf']").attr('content');

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -19,6 +19,14 @@
                 독서실 이용 히스토리가 없습니다.
             </P>
             <div th:if="${histories.numberOfElements} != 0">
+                <div class="flex justify-center items-center gap-3">
+                    <span><i class="fa-regular fa-calendar"></i> 날짜 검색</span>
+                    <input id="searchDate" type="date" class="px-3 rounded"
+                           style="border: 1px solid rgb(58, 191, 248);"/>
+                    <button onclick="javascript:loadHistories(0);">
+                        <i class="fa-solid fa-magnifying-glass"></i>
+                    </button>
+                </div>
                 <div class="overflow-x-auto">
                     <table class="table text-center">
                         <!-- head -->
@@ -35,48 +43,26 @@
 
                         <!-- 페이지 변수를 받아서 thymeleaf로 작성하기 -->
                         <tbody id="contentList">
-                        <!-- row 1 -->
-                        <tr th:each="history : ${histories}">
-                            <td th:text="${#temporals.format(history.date, 'yyyy.MM.dd HH:mm:ss')}"></td>
-                            <td th:text="${history.user.account.fullName}" style="min-width: 86px;"></td>
-                            <td th:text="${history.addressToString}"></td>
-                            <td th:text="${history.seat.seatNumber}"></td>
-                            <td th:text="${history.statusTypeToString}" style="min-width:80px; padding: 12px 0;"></td>
-                            <td th:if="${history.statusType} == 0" style="min-width:100px; padding: 12px 0;">
-                                <button th:onclick="submitAdminCancel([[${history.id}]])"
-                                        class="btn btn-info btn-sm text-white cancel-button">
-                                    취소하기
-                                </button>
-                            </td>
-                        </tr>
+
                         </tbody>
 
                     </table>
                 </div>
 
                 <!-- 넘버링 페이지 -->
-                <div class="btn-group flex justify-center mt-7" th:if="${!histories.isEmpty()}">
-                    <div class="btn" th:classappend="${histories.number == 0} ? 'btn-disabled' : ''"
-                         th:attr="onclick='window.location.href=\'?page=0&size=25\''">
+                <div class="btn-group flex justify-center mt-7">
+                    <div id="first" class="btn" onclick="loadHistories(0)">
                         &laquo;
                     </div>
-                    <div th:attr="onclick='window.location.href=\'?page=' + (${histories.number - 1}) + '&size=25\''"
-                         class="btn" th:classappend="${!histories.hasPrevious} ? 'btn-disabled' : ''">
+                    <div id="prev" class="btn" onclick="loadHistories(pageNumber - 1)">
                         이전
                     </div>
-                    <div class="btn" th:each="page: ${#numbers.sequence(0, histories.totalPages - 1)}"
-                         th:classappend="${histories.number == page} ? 'btn-active' : ''"
-                         th:if="${page >= histories.number - 1 and page <= histories.number + 2}"
-                         th:attr="onclick='window.location.href=\'?page=' + (${page}) + '&size=25\''"
-                         th:text="${page+1}">
+                    <div id="paging-nav">
                     </div>
-                    <div class="btn" th:classappend="${!histories.hasNext} ? 'btn-disabled' :''"
-                         th:attr="onclick='window.location.href=\'?page=' + (${histories.number + 1}) + '&size=25\''">
+                    <div id="next" class="btn" onclick="loadHistories(pageNumber + 1)">
                         다음
                     </div>
-                    <div th:attr="onclick='window.location.href=\'?page=' + (${histories.totalPages - 1}) + '&size=25\''"
-                         class="btn"
-                         th:classappend="${histories.number == histories.totalPages - 1} ? 'btn-disabled' : ''">
+                    <div id="last" class="btn" onclick="loadHistories(totalPages - 1)">
                         &raquo;
                     </div>
                 </div>
@@ -84,6 +70,104 @@
         </div>
     </div>
     <script>
+        let pageNumber = 0;
+        let totalPages = 0;
+
+        function setPagingNav(data) {
+            pageNumber = data.number;
+            totalPages = data.totalPages;
+
+            if (pageNumber == 0) {
+                $("#first").addClass('btn-disabled');
+            } else {
+                $("#first").removeClass('btn-disabled');
+            }
+
+            if (pageNumber <= 0) {
+                $("#prev").addClass('btn-disabled');
+            } else {
+                $("#prev").removeClass('btn-disabled');
+            }
+
+            if (pageNumber + 1 >= totalPages) {
+                $("#next").addClass('btn-disabled');
+            } else {
+                $("#next").removeClass('btn-disabled');
+            }
+
+            if (pageNumber == totalPages - 1) {
+                $("#last").addClass('btn-disabled');
+            } else {
+                $("#last").removeClass('btn-disabled');
+            }
+
+            let pagingNav = '';
+
+            for (let page = 0; page < totalPages; page++) {
+                if (page < pageNumber - 1 || page > pageNumber + 2) {
+                    continue;
+                }
+                if (pageNumber === page) {
+                    pagingNav += `<div class='btn btn-active' onClick='loadHistories(${page})'>${page + 1}</div>`;
+                } else {
+                    pagingNav += `<div class='btn' onClick='loadHistories(${page})'>${page + 1}</div>`;
+                }
+            }
+            $('#paging-nav').html(pagingNav);
+        }
+
+        function loadHistories(currPage) {
+            let header = $("meta[name='_csrf_header']").attr('content');
+            let token = $("meta[name='_csrf']").attr('content');
+            let searchDate = $("#searchDate").val();
+            let url = '/admin/library/histories';
+
+            if (searchDate.trim().length === 0) {
+                url = '/admin/library/histories/all';
+            }
+
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: Object.assign(
+                    {page: currPage},
+                    searchDate.trim().length !== 0 ? {searchDate: searchDate} : {}
+                ),
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader(header, token);
+                },
+                success: function (data) {
+                    // 결과가 성공적으로 수신되면 테이블에 로우 추가
+                    console.log(data);
+                    let contentList = '';
+                    $.each(data.content, function (index, history) {
+                        let newRow = `<tr>
+                            <td>${dateFormat(history.date)}</td>
+                            <td style="min-width: 86px;">${history.user.account.fullName}</td>
+                            <td>${history.addressToString}</td>
+                            <td>${history.seat.seatNumber}</td>
+                            <td style="min-width:80px; padding: 12px 0;">${history.statusTypeToString}</td>`;
+                        if (history.statusType === 0) {
+                            newRow += `<td style="min-width:100px; padding: 12px 0;">
+                                <button onclick="submitAdminCancel(${history.id})"
+                                        class="btn btn-info btn-sm text-white cancel-button">
+                                    취소하기
+                                </button>
+                            </td>`;
+                        }
+                        newRow += `</tr>`;
+                        contentList += newRow;
+                    });
+                    $('#contentList').html(contentList);
+                    setPagingNav(data);
+                    $('html').scrollTop(0);
+                },
+                error: function (err) {
+                    console.log("Error fetching data:", err);
+                }
+            });
+        }
+
         function submitAdminCancel(historyId) {
             let header = $("meta[name='_csrf_header']").attr('content');
             let token = $("meta[name='_csrf']").attr('content');
@@ -106,6 +190,8 @@
                 }
             });
         }
+
+        loadHistories(0);
     </script>
 </main>
 </body>

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -20,12 +20,16 @@
             </P>
             <div id="hasHistory" class="hidden">
                 <div class="flex justify-center items-center gap-3">
-                    <span><i class="fa-regular fa-calendar"></i> 날짜 검색</span>
-                    <input id="searchDate" type="date" class="px-3 rounded"
-                           style="border: 1px solid rgb(58, 191, 248);"/>
-                    <button onclick="javascript:loadHistories(0);">
-                        <i class="fa-solid fa-magnifying-glass"></i>
-                    </button>
+                    <span>날짜 검색</span>
+                    <div class="join">
+                        <input id="searchDate" type="date" class="join-item px-1 rounded"
+                               style="border: 1px solid #dfdfdf;"/>
+                        <div class="indicator">
+                            <button onclick="javascript:loadHistories(0);" class="btn join-item p-3 rounded">
+                                <i class="fa-solid fa-magnifying-glass"></i>
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div class="overflow-x-auto">
                     <table class="table text-center">

--- a/src/main/resources/templates/admin/library/histories.html
+++ b/src/main/resources/templates/admin/library/histories.html
@@ -15,10 +15,10 @@
         <div class="card-body p-3">
             <h2 class="card-title">이용 현황</h2>
 
-            <P th:if="${histories.numberOfElements} == 0" class="text-center my-5">
+            <P id="noHistory" class="text-center my-5 hidden">
                 독서실 이용 히스토리가 없습니다.
             </P>
-            <div th:if="${histories.numberOfElements} != 0">
+            <div id="hasHistory" class="hidden">
                 <div class="flex justify-center items-center gap-3">
                     <span><i class="fa-regular fa-calendar"></i> 날짜 검색</span>
                     <input id="searchDate" type="date" class="px-3 rounded"
@@ -138,7 +138,14 @@
                 },
                 success: function (data) {
                     // 결과가 성공적으로 수신되면 테이블에 로우 추가
-                    console.log(data);
+                    if (data.numberOfElements === 0) {
+                        $('#noHistory').removeClass('hidden');
+                        $('#hasHistory').addClass('hidden');
+                    } else {
+                        $('#noHistory').addClass('hidden');
+                        $('#hasHistory').removeClass('hidden');
+                    }
+
                     let contentList = '';
                     $.each(data.content, function (index, history) {
                         let newRow = `<tr>


### PR DESCRIPTION
<!-- pull_request_docs.md 파일은 기본 주소 뒤에 ?template=pull_request_docs.md 를 붙여서 접속합니다. -->
<!-- 예시 : https://github.com/SoloForest/TownForest/compare/main...enhancement1/templates?template=pull_request.docs.md -->

## Description
독서실 관리자 히스토리 페이지를 리펙토링 했습니다.
1. 넘버링 페이지로 변환
2. 날짜별 검색(필터링)

## Changes

- **boundedContext/home/controller/AdminController.java**
    - [x] showAdmin(), showLibraryHistories(), showGuestVehicles()
        - rq.historyBack() 함수 활용하여 예외처리 하도록 변경

- **boundedContext/home/controller/AdminController.java**
    - [x] showLibraryHistories()
        - 초기에 히스토리 데이터 가져오지 않고, ajax 통신을 통해 데이터 가져오도록 수정
        - 새로고침 할 때 날짜검색 초기화되도록 하기 위함
    - [x] histories(int page, LocalDate searchDate)
        - 페이징과 날짜 검색을 함께함
    - [x] histories(int page)
        - 전체 날짜의 결과에 대해 페이징

- **templates/admin/library/histories.html**
    - [x] setPagingNav()
        - 페이지바의 버튼 눌림 여부를 조작합니다. (disabled)
    - [x] loadHistories()
        - 날짜 검색 여부에 따라 API 주소 선택
            - [x] 날짜 검색인 경우 ```'/admin/library/histories' -> history(page, searchDate)``` 
            - [x] 전체 히스토리의 경우 ```'/admin/library/histories/all' -> history(page)```
        - ajax 결과에 따른 table-body 생성
        - get으로 불러온 페이지는 '이용 내역이 없습니다'안내 문구, 이용 내역 테이블 모두 hidden이고,   
         ajax로 결과를 받아와 어떤걸 보여줄지 선택하게 했습니다.

### ETC


---
Close #79 