### PR TITLE
Enhancement78/withdraw

### DIFF
--- a/src/main/java/com/ll/townforest/base/event/EventAccountWithdraw.java
+++ b/src/main/java/com/ll/townforest/base/event/EventAccountWithdraw.java
@@ -1,0 +1,17 @@
+package com.ll.townforest.base.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.ll.townforest.boundedContext.account.entity.Account;
+
+import lombok.Getter;
+
+@Getter
+public class EventAccountWithdraw extends ApplicationEvent {
+	private final Account account;
+
+	public EventAccountWithdraw(Object source, Account account) {
+		super(source);
+		this.account = account;
+	}
+}

--- a/src/main/java/com/ll/townforest/base/event/EventAccountWithdraw.java
+++ b/src/main/java/com/ll/townforest/base/event/EventAccountWithdraw.java
@@ -2,16 +2,16 @@ package com.ll.townforest.base.event;
 
 import org.springframework.context.ApplicationEvent;
 
-import com.ll.townforest.boundedContext.account.entity.Account;
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 
 import lombok.Getter;
 
 @Getter
 public class EventAccountWithdraw extends ApplicationEvent {
-	private final Account account;
+	private final AptAccount aptAccount;
 
-	public EventAccountWithdraw(Object source, Account account) {
+	public EventAccountWithdraw(Object source, AptAccount aptAccount) {
 		super(source);
-		this.account = account;
+		this.aptAccount = aptAccount;
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/controller/AccountController.java
@@ -72,11 +72,13 @@ public class AccountController {
 		return rq.redirectWithMsg("/account/edit", accountRsData);
 	}
 
+	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/confirmPwd")
 	public @ResponseBody boolean confirmPassword(@RequestParam String password) {
 		return accountService.confirmPassword(rq.getAccount(), password);
 	}
 
+	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/withdraw")
 	public String withdraw(HttpServletRequest request, HttpServletResponse response) {
 		RsData<Account> accountRsData = accountService.withdraw(rq.getAccount(), request, response);

--- a/src/main/java/com/ll/townforest/boundedContext/account/controller/AccountController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/controller/AccountController.java
@@ -16,6 +16,8 @@ import com.ll.townforest.boundedContext.account.entity.Account;
 import com.ll.townforest.boundedContext.account.service.AccountService;
 import com.ll.townforest.boundedContext.apt.DTO.EditForm;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -73,5 +75,15 @@ public class AccountController {
 	@GetMapping("/confirmPwd")
 	public @ResponseBody boolean confirmPassword(@RequestParam String password) {
 		return accountService.confirmPassword(rq.getAccount(), password);
+	}
+
+	@PostMapping("/withdraw")
+	public String withdraw(HttpServletRequest request, HttpServletResponse response) {
+		RsData<Account> accountRsData = accountService.withdraw(rq.getAccount(), request, response);
+
+		if (accountRsData.isFail()) {
+			return rq.historyBack(accountRsData);
+		}
+		return rq.redirectWithMsg("/", accountRsData);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
@@ -118,7 +118,7 @@ public class AccountService {
 	public RsData<Account> withdraw(Account account, HttpServletRequest request, HttpServletResponse response) {
 		Optional<AptAccount> aptAccount = aptAccountRepository.findByAccount(account);
 		if (aptAccount.isPresent()) {
-			// 회원에게 헬스장 이용권의 상태가 이용 대기중일 시 탈퇴 불가
+			// 회원의 헬스장 이용권 상태가 이용 대기중일 시 탈퇴 불가
 			List<GymMembership> gymMembershipList = gymMembershipRepository.findByUserAndStatus(aptAccount.get(), 0);
 			if (gymMembershipList.size() != 0)
 				return RsData.of("F-1", "죄송합니다.<br>아직 유효한 헬스장 이용권이 남아있어 계정 탈퇴를 진행할 수 없습니다.");
@@ -134,6 +134,7 @@ public class AccountService {
 
 		accountRepository.delete(account);
 
+		// 데이터 삭제 후 로그아웃
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		if (auth != null) {
 			new SecurityContextLogoutHandler().logout(request, response, auth);

--- a/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
@@ -134,12 +134,13 @@ public class AccountService {
 					.build();
 				aptAccountHouseRepository.save(aptAccountHouse);
 			}
+
+			// 계정 탈퇴 시 이벤트 발생 -> 이용권 삭제 처리를 위함
+			// AptAccount가 있어야 Gym 이용이 가능하니, 없을땐 이벤트 발생x
+			publisher.publishEvent(new EventAccountWithdraw(this, aptAccount.get()));
 		}
 
 		accountRepository.delete(account);
-
-		// 계정 탈퇴 시 이벤트 발생 -> 이용권 삭제 처리
-		publisher.publishEvent(new EventAccountWithdraw(this, account));
 
 		// 데이터 삭제 후 로그아웃
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/account/service/AccountService.java
@@ -3,6 +3,7 @@ package com.ll.townforest.boundedContext.account.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -12,6 +13,7 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ll.townforest.base.event.EventAccountWithdraw;
 import com.ll.townforest.base.rsData.RsData;
 import com.ll.townforest.boundedContext.account.dto.AccountDTO;
 import com.ll.townforest.boundedContext.account.entity.Account;
@@ -38,6 +40,8 @@ public class AccountService {
 	private final AptAccountRepository aptAccountRepository;
 	private final AptAccountHouseRepository aptAccountHouseRepository;
 	private final GymMembershipRepository gymMembershipRepository;
+
+	private final ApplicationEventPublisher publisher;
 
 	public Optional<Account> findByUsername(String username) {
 		return accountRepository.findByUsername(username);
@@ -133,6 +137,9 @@ public class AccountService {
 		}
 
 		accountRepository.delete(account);
+
+		// 계정 탈퇴 시 이벤트 발생 -> 이용권 삭제 처리
+		publisher.publishEvent(new EventAccountWithdraw(this, account));
 
 		// 데이터 삭제 후 로그아웃
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/ll/townforest/boundedContext/apt/entity/AptAccount.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/entity/AptAccount.java
@@ -1,5 +1,7 @@
 package com.ll.townforest.boundedContext.apt.entity;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.ll.townforest.boundedContext.account.entity.Account;
@@ -28,7 +30,8 @@ public class AptAccount {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	@OneToOne
+	@OneToOne(orphanRemoval = true)
+	@OnDelete(action = OnDeleteAction.SET_NULL)
 	private Account account;
 	@ManyToOne
 	private Apt apt;

--- a/src/main/java/com/ll/townforest/boundedContext/apt/entity/AptAccountHouse.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/entity/AptAccountHouse.java
@@ -34,4 +34,13 @@ public class AptAccountHouse {
 	private AptAccount user;
 	@ManyToOne
 	private House house;
+
+	/*
+	 * 탈퇴한 회원을 나타내는 변수
+	 * true: 탈퇴한 회원
+	 * false: 유효한 회원
+	 * default : false (유효한 회원)
+	 */
+	@Builder.Default
+	private boolean status = false;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
@@ -14,11 +14,11 @@ public interface AptAccountHouseRepository extends JpaRepository<AptAccountHouse
 
 	List<AptAccountHouse> findAllByHouseId(Long houseId);
 
-	List<AptAccountHouse> findByUser_StatusTrueOrderByUserIdDesc();
+	List<AptAccountHouse> findByUser_StatusTrueAndStatusFalseOrderByUserIdDesc();
 
-	List<AptAccountHouse> findByUser_StatusFalseOrderByUserIdDesc();
+	List<AptAccountHouse> findByUser_StatusFalseAndStatusFalseOrderByUserIdDesc();
 
-	List<AptAccountHouse> findAllByOrderByIdDesc();
+	List<AptAccountHouse> findAllByStatusFalseOrderByIdDesc();
 
 	Optional<AptAccountHouse> findByUser(AptAccount aptAccount);
 

--- a/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/repository/AptAccountHouseRepository.java
@@ -22,5 +22,5 @@ public interface AptAccountHouseRepository extends JpaRepository<AptAccountHouse
 
 	Optional<AptAccountHouse> findByUser(AptAccount aptAccount);
 
-	List<AptAccountHouse> findAllByHouse(House house);
+	List<AptAccountHouse> findAllByHouseAndStatusFalse(House house);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountHouseService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountHouseService.java
@@ -29,12 +29,12 @@ public class AptAccountHouseService {
 		return aptAccountHouseRepository.findByUser(aptAccount);
 	}
 
-	public List<AptAccountHouse> findAptAccountHouse(int sortCode) {
+	public List<AptAccountHouse> findAptAccountHouseBySortCode(int sortCode) {
 
 		return switch (sortCode) {
-			case 2 -> aptAccountHouseRepository.findByUser_StatusTrueOrderByUserIdDesc();
-			case 3 -> aptAccountHouseRepository.findByUser_StatusFalseOrderByUserIdDesc();
-			default -> aptAccountHouseRepository.findAllByOrderByIdDesc();
+			case 2 -> aptAccountHouseRepository.findByUser_StatusTrueAndStatusFalseOrderByUserIdDesc();
+			case 3 -> aptAccountHouseRepository.findByUser_StatusFalseAndStatusFalseOrderByUserIdDesc();
+			default -> aptAccountHouseRepository.findAllByStatusFalseOrderByIdDesc();
 		};
 	}
 

--- a/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountService.java
@@ -85,7 +85,7 @@ public class AptAccountService {
 		if (aptAccountHouse == null)
 			return null;
 		House house = aptAccountHouse.getHouse();
-		List<AptAccountHouse> household = aptAccountHouseRepository.findAllByHouse(house);
+		List<AptAccountHouse> household = aptAccountHouseRepository.findAllByHouseAndStatusFalse(house);
 		household.remove(aptAccountHouse);
 
 		return household;

--- a/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/controller/GymController.java
@@ -177,7 +177,7 @@ public class GymController {
 
 		// 아파트 여러개라면 현재 로그인한 사용자가 속한 Gym ID를 넘긴다.
 		// 현재 하나이기에 1로 하드코딩
-		List<GymTicket> gymTicketList = gymService.getGymTickets(1L);
+		List<GymTicket> gymTicketList = gymService.getGymTicketList(1L);
 
 		model.addAttribute("gymTicketList", gymTicketList);
 

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymHistory.java
@@ -70,4 +70,5 @@ public class GymHistory {
 	private LocalDate restartDate;
 	private String address;
 	private String contact;
+	private String userName;
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/entity/GymMembership.java
@@ -40,6 +40,7 @@ public class GymMembership {
 	private Apt apt;
 	private String address;
 	private String contact;
+	private String userName;
 	private LocalDate startDate;
 	private LocalDate endDate;
 

--- a/src/main/java/com/ll/townforest/boundedContext/gym/eventListener/GymEventListener.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/eventListener/GymEventListener.java
@@ -17,6 +17,6 @@ public class GymEventListener {
 
 	@EventListener
 	public void listen(EventAccountWithdraw event) {
-		gymService.whenAccountWithdraw(event.getAccount());
+		gymService.whenAccountWithdraw(event.getAptAccount());
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/eventListener/GymEventListener.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/eventListener/GymEventListener.java
@@ -1,0 +1,22 @@
+package com.ll.townforest.boundedContext.gym.eventListener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.townforest.base.event.EventAccountWithdraw;
+import com.ll.townforest.boundedContext.gym.service.GymService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class GymEventListener {
+	private final GymService gymService;
+
+	@EventListener
+	public void listen(EventAccountWithdraw event) {
+		gymService.whenAccountWithdraw(event.getAccount());
+	}
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.ll.townforest.boundedContext.account.entity.Account;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
 
@@ -49,5 +48,5 @@ public interface GymMembershipRepository extends JpaRepository<GymMembership, Lo
 
 	List<GymMembership> findByUserAndStatus(AptAccount user, int status);
 
-	List<GymMembership> findByAccount(Account account);
+	List<GymMembership> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
@@ -4,14 +4,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
 
 public interface GymMembershipRepository extends JpaRepository<GymMembership, Long> {
@@ -20,6 +19,7 @@ public interface GymMembershipRepository extends JpaRepository<GymMembership, Lo
 	List<GymMembership> findAllByEndDateAndStatusNot(LocalDate endDate, int status);
 
 	List<GymMembership> findAllByStartDateAndStatus(LocalDate today, int status);
+
 	// 관리자 화면에서 인원수를 나타내기 위한 리스트
 	List<GymMembership> findByGymId(Long gymId);
 
@@ -45,4 +45,6 @@ public interface GymMembershipRepository extends JpaRepository<GymMembership, Lo
 		+ "where "
 		+ "a.fullName like %:kw% ")
 	Page<GymMembership> findAllByFullName(@Param("kw") String kw, Pageable pageable);
+
+	List<GymMembership> findByUserAndStatus(AptAccount user, int status);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/repository/GymMembershipRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.ll.townforest.boundedContext.account.entity.Account;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.gym.entity.GymMembership;
 
@@ -47,4 +48,6 @@ public interface GymMembershipRepository extends JpaRepository<GymMembership, Lo
 	Page<GymMembership> findAllByFullName(@Param("kw") String kw, Pageable pageable);
 
 	List<GymMembership> findByUserAndStatus(AptAccount user, int status);
+
+	List<GymMembership> findByAccount(Account account);
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.townforest.base.rq.Rq;
 import com.ll.townforest.base.rsData.RsData;
+import com.ll.townforest.boundedContext.account.entity.Account;
 import com.ll.townforest.boundedContext.apt.entity.Apt;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.apt.service.AptAccountService;
@@ -462,5 +463,12 @@ public class GymService {
 		gymTicketRepository.delete(gymTicket);
 
 		return RsData.of("S-1", "이용권 삭제 성공");
+	}
+
+	@Transactional
+	public void whenAccountWithdraw(Account account) {
+		List<GymMembership> gymMembershipList = gymMembershipRepository.findByAccount(account);
+
+		gymMembershipRepository.deleteAll(gymMembershipList);
 	}
 }

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.townforest.base.rq.Rq;
 import com.ll.townforest.base.rsData.RsData;
-import com.ll.townforest.boundedContext.account.entity.Account;
 import com.ll.townforest.boundedContext.apt.entity.Apt;
 import com.ll.townforest.boundedContext.apt.entity.AptAccount;
 import com.ll.townforest.boundedContext.apt.service.AptAccountService;
@@ -466,8 +465,8 @@ public class GymService {
 	}
 
 	@Transactional
-	public void whenAccountWithdraw(Account account) {
-		List<GymMembership> gymMembershipList = gymMembershipRepository.findByAccount(account);
+	public void whenAccountWithdraw(AptAccount user) {
+		List<GymMembership> gymMembershipList = gymMembershipRepository.findAllByUserId(user.getId());
 
 		gymMembershipRepository.deleteAll(gymMembershipList);
 	}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/service/GymService.java
@@ -68,27 +68,30 @@ public class GymService {
 		if (startDate.isAfter(LocalDate.now())) {
 			status = 0;
 		}
-
-		String userHasAddress = aptAccountService.makeAddressToString(user).getData();
+		String userName = user.getAccount().getFullName();
+		String contact = user.getAccount().getPhoneNumString();
+		String userAddress = aptAccountService.makeAddressToString(user).getData();
+		Gym gym = gymRepository.findById(1L).orElse(null);
+		Apt apt = user.getApt();
 
 		GymMembership tmp = GymMembership.builder()
-			.apt(user.getApt())
-			.gym(gymRepository.findById(1L).orElse(null))
+			.apt(apt)
+			.gym(gym)
 			.startDate(startDate)
 			.endDate(endDate)
 			.user(user)
 			.status(status)
+			.userName(userName != null ? userName : "알수없음")
 			.paymentDate(LocalDateTime.now())
-			.contact(user.getAccount().getPhoneNumString())
-			.address(userHasAddress != null ?
-				aptAccountService.makeAddressToString(user).getData() : "알수없음")
+			.contact(contact != null ? contact : "알수없음")
+			.address(userAddress != null ? userAddress : "알수없음")
 			.build();
 
 		gymMembershipRepository.save(tmp);
 
 		GymHistory tmp2 = GymHistory.builder()
-			.apt(user.getApt())
-			.gym(gymRepository.findById(1L).orElse(null))
+			.apt(apt)
+			.gym(gym)
 			.price(gymTicket.getPrice())
 			.name(gymTicket.getName())
 			.startDate(startDate)
@@ -97,16 +100,16 @@ public class GymService {
 			.paymentMethod(method)
 			.paymentDate(LocalDateTime.now())
 			.user(user)
-			.contact(user.getAccount().getPhoneNumString() != null ? user.getAccount().getPhoneNumString() : "알수없음")
-			.address(userHasAddress != null ?
-				aptAccountService.makeAddressToString(user).getData() : "알수없음")
+			.userName(userName != null ? userName : "알수없음")
+			.contact(contact != null ? contact : "알수없음")
+			.address(userAddress != null ? userAddress : "알수없음")
 			.build();
 
 		gymHistoryRepository.save(tmp2);
 
 	}
 
-	public List<GymTicket> getGymTickets(Long gymId) {
+	public List<GymTicket> getGymTicketList(Long gymId) {
 
 		return gymTicketRepository.findAllByGymIdOrderByPrice(gymId);
 
@@ -143,9 +146,13 @@ public class GymService {
 			.build();
 		gymMembershipRepository.save(updateMembership);
 
+		String userName = user.getAccount().getFullName();
+		String contact = user.getAccount().getPhoneNumString();
+		String userAddress = aptAccountService.makeAddressToString(user).getData();
+
 		GymHistory tmp2 = GymHistory.builder()
 			.apt(user.getApt())
-			.gym(gymRepository.findById(1L).orElse(null))
+			.gym(updateMembership.getGym())
 			.price(gymTicket.getPrice())
 			.name(gymTicket.getName())
 			.startDate(startDate)
@@ -153,6 +160,9 @@ public class GymService {
 			.status(1) // 1은 연장을 나타냄
 			.paymentMethod(method)
 			.user(user)
+			.userName(userName != null ? userName : "알수없음")
+			.contact(contact != null ? contact : "알수없음")
+			.address(userAddress != null ? userAddress : "알수없음")
 			.build();
 
 		gymHistoryRepository.save(tmp2);
@@ -177,7 +187,7 @@ public class GymService {
 			return RsData.of("F-1", "당일 종료권 또는 기한 지난 이용권은 일시정지가 불가능합니다.");
 
 		GymMembership tmp = pauseMembership.toBuilder()
-			.status(2)
+			.status(2) // 2는 일시정지상태
 			.pauseDate(localDate)
 			.remainingDay((int)remainingDay)
 			.build();
@@ -185,6 +195,10 @@ public class GymService {
 		AptAccount user = pauseMembership.getUser();
 
 		gymMembershipRepository.save(tmp);
+
+		String userName = user.getAccount().getFullName();
+		String contact = user.getAccount().getPhoneNumString();
+		String userAddress = aptAccountService.makeAddressToString(user).getData();
 
 		GymHistory tmp2 = GymHistory.builder()
 			.status(2)
@@ -195,6 +209,9 @@ public class GymService {
 			.user(tmp.getUser())
 			.startDate(tmp.getStartDate())
 			.endDate(tmp.getEndDate())
+			.userName(userName != null ? userName : "알수없음")
+			.contact(contact != null ? contact : "알수없음")
+			.address(userAddress != null ? userAddress : "알수없음")
 			.build();
 
 		gymHistoryRepository.save(tmp2);
@@ -214,7 +231,7 @@ public class GymService {
 		LocalDate updatedEndDate = pauseDate.plusDays(remainingDay);
 
 		GymMembership tmp = pauseMembership.toBuilder()
-			.status(4)
+			.status(4)  // 4는 재시작을 나타냄
 			.pauseDate(null)
 			.remainingDay(null)
 			.endDate(updatedEndDate)
@@ -222,6 +239,12 @@ public class GymService {
 			.build();
 
 		gymMembershipRepository.save(tmp);
+
+		AptAccount user = pauseMembership.getUser();
+
+		String userName = user.getAccount().getFullName();
+		String contact = user.getAccount().getPhoneNumString();
+		String userAddress = aptAccountService.makeAddressToString(user).getData();
 
 		GymHistory tmp2 = GymHistory.builder()
 			.status(3)
@@ -231,6 +254,9 @@ public class GymService {
 			.startDate(tmp.getStartDate())
 			.endDate(tmp.getEndDate())
 			.restartDate(localDate)
+			.userName(userName != null ? userName : "알수없음")
+			.contact(contact != null ? contact : "알수없음")
+			.address(userAddress != null ? userAddress : "알수없음")
 			.build();
 
 		gymHistoryRepository.save(tmp2);
@@ -253,6 +279,13 @@ public class GymService {
 
 		// 누가 언제부터 언제까지 이용했던 헬스장 이용권 만료되었다 히스토리 남기기
 		for (GymMembership gymMembership : list) {
+
+			AptAccount user = gymMembership.getUser();
+
+			String userName = user.getAccount().getFullName();
+			String contact = user.getAccount().getPhoneNumString();
+			String userAddress = aptAccountService.makeAddressToString(user).getData();
+
 			GymHistory tmp = GymHistory.builder()
 				.status(4) // 4는 만료
 				.gym(gymMembership.getGym())
@@ -260,6 +293,9 @@ public class GymService {
 				.endDate(gymMembership.getEndDate())
 				.apt(gymMembership.getApt())
 				.user(gymMembership.getUser())
+				.userName(userName != null ? userName : "알수없음")
+				.contact(contact != null ? contact : "알수없음")
+				.address(userAddress != null ? userAddress : "알수없음")
 				.build();
 
 			histories.add(tmp);

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -171,7 +171,7 @@ public class AdminController {
 			return "redirect:/admin";
 		}
 
-		List<AptAccountHouse> aptAccountHouseList = aptAccountHouseService.findAptAccountHouse(sortCode);
+		List<AptAccountHouse> aptAccountHouseList = aptAccountHouseService.findAptAccountHouseBySortCode(sortCode);
 
 		model.addAttribute("aptAccountHouseList", aptAccountHouseList);
 		model.addAttribute("sortCode", sortCode);

--- a/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
+++ b/src/main/java/com/ll/townforest/boundedContext/home/controller/AdminController.java
@@ -199,7 +199,7 @@ public class AdminController {
 			return rq.historyBack("헬스장 관리자만 접속 가능합니다");
 
 		// TODO : 아파트가 우선 1개이기에 하드코딩, 여러개 될 시 관리자가 관리하는 gym 넣어주기
-		List<GymTicket> gymTicketList = gymService.getGymTickets(1L);
+		List<GymTicket> gymTicketList = gymService.getGymTicketList(1L);
 		model.addAttribute("gymTicketList", gymTicketList);
 
 		return "admin/gym/ticket/ticket";

--- a/src/main/resources/static/js/editForm_validation.js
+++ b/src/main/resources/static/js/editForm_validation.js
@@ -114,3 +114,10 @@ $("#confirm").on("click", function () {
         }
     });
 });
+
+function withdraw() {
+    if (confirm('정말 탈퇴하시겠습니까?\n이 작업은 되돌릴 수 없습니다.')) {
+        document.querySelector('#withdrawForm').submit();
+        alert('정상적으로 회원 탈퇴가 처리되었습니다.\n그동안 저희 서비스를 이용해주셔서 감사합니다.');
+    }
+}

--- a/src/main/resources/templates/account/edit.html
+++ b/src/main/resources/templates/account/edit.html
@@ -90,10 +90,10 @@
                     </div>
                 </form>
 
-                <div class="flex justify-end">
+                <div x-show="editing" class="flex justify-end">
                     <a class="link mr-2 text-xs text-gray-400" href="javascript:"
-                       onclick="$(this).next().submit();">회원탈퇴</a>
-                    <form class="!hidden" method="POST"></form>
+                       onclick="withdraw();">회원탈퇴</a>
+                    <form class="!hidden" id="withdrawForm" th:action="|/account/withdraw|" method="POST"></form>
                 </div>
 
                 <!-- Main modal -->

--- a/src/main/resources/templates/admin/aptAccount/management.html
+++ b/src/main/resources/templates/admin/aptAccount/management.html
@@ -59,7 +59,7 @@
                                 <div class="font-medium text-gray-700">
                                     <span th:text="${list.house.dong} +'동 '+ ${list.house.ho} +'호'"></span>
                                 </div>
-                                <span th:text="${list.relationship}"
+                                <span th:text="${(list.relationship == '본인') ? '세대주' : list.relationship}"
                                       class="font-medium text-gray-400"></span>
                             </div>
                         </th>
@@ -107,7 +107,7 @@
                                       method="POST" id="approvalForm">
                                     <input type="hidden" name="sortCode" th:value="${sortCode}"/>
                                 </form>
-                                <a href="javascript:"
+                                <a th:if="${!list.user.status}" href="javascript:"
                                    th:attr="data-id=${list.id}"
                                    onclick="DeleteForm_submit(this);">
                                     <svg xmlns="http://www.w3.org/2000/svg"

--- a/src/main/resources/templates/admin/gym/history.html
+++ b/src/main/resources/templates/admin/gym/history.html
@@ -43,7 +43,7 @@
                     <td th:text="${(paging.number * paging.size) + loop.index +1}"
                         style="min-width:40px; padding: 12px 0;"></td>
                     <td th:text="${gymHistory.address}" style="min-width:60px; padding: 12px 0;"></td>
-                    <td th:text="${gymHistory.user.account.fullName}" style="min-width:40px; padding: 12px 0;"></td>
+                    <td th:text="${gymHistory.userName}" style="min-width:40px; padding: 12px 0;"></td>
                     <td th:if="${gymHistory.restartDate ==null}"
                         th:text="${#temporals.format(gymHistory.startDate, 'yy-MM-dd')}"
                         style="min-width:80px; padding: 12px 0;"></td>

--- a/src/main/resources/templates/admin/gym/members.html
+++ b/src/main/resources/templates/admin/gym/members.html
@@ -47,7 +47,7 @@
                     <td th:text="${(paging.number * paging.size) + loop.index +1}"
                         style="min-width:40px; padding: 12px 0;"></td>
                     <td th:text="${gymMember.address}" style="min-width:60px; padding: 12px 0;"></td>
-                    <td th:text="${gymMember.user.account.fullName}"
+                    <td th:text="${gymMember.userName}"
                         style="min-width:40px; padding: 12px 0;"></td>
                     <td th:text="${#temporals.format(gymMember.startDate, 'yy-MM-dd')}"
                         style="min-width:80px; padding: 12px 0;"></td>

--- a/src/main/resources/templates/aptAccount/me.html
+++ b/src/main/resources/templates/aptAccount/me.html
@@ -25,7 +25,7 @@
                         </a>
                     </label>
                 </div>
-                <div th:if="${household} != null">
+                <div th:if="${household} != null and ${household.size() != 0}">
                     <h3 class="px-4 m-2 font-semibold text-left">세대원 정보</h3>
                     <div class="rounded-box flex justify-center">
                         <div class="bg-white border border-gray-500 shadow-md w-80 min-h-24 rounded-3xl p-2 flex flex-col justify-center items-center">

--- a/src/main/resources/templates/gym/gym.html
+++ b/src/main/resources/templates/gym/gym.html
@@ -14,7 +14,7 @@
                 <div class="flex items-center gap-2">
                     <i class="fa-solid fa-user" style="color: #91c0fd;"></i>
                     <div class="flex items-center">
-                        <p class="font-bold" th:text="${gymMembership.user.account.fullName}"></p>
+                        <p class="font-bold" th:text="${gymMembership.userName}"></p>
                         <p>님</p>
                     </div>
                 </div>

--- a/src/main/resources/templates/gym/pause.html
+++ b/src/main/resources/templates/gym/pause.html
@@ -17,7 +17,7 @@
                 <div class="flex items-center gap-2 mt-8">
                     <i class="fa-solid fa-user" style="color: #91c0fd;"></i>
                     <div class="flex items-center">
-                        <p class="font-bold" th:text="${user.account.fullName}"></p>
+                        <p class="font-bold" th:text="${membership.userName}"></p>
                         <p>님</p>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
회원 탈퇴 기능을 구현했습니다.

## Changes

- **boundedContext/account/controller/AccountController.java**
    - [x] withdraw()
        - 회원 탈퇴 메서드를 실행합니다.
        - 실패 시 historyBack 합니다.

- **boundedContext/account/service/AccountService.java**
    - [x] witdraw()
        - 탈퇴하는 회원의 이용권 상태가 이용 대기중일 시 탈퇴가 불가능합니다.
        - 탈퇴하는 회원의 aptAccoutHouse의 status(탈퇴한 회원인지 나타내는 변수)를 true로 저장합니다.
        - Account 데이터 삭제 후 이벤트를 발생시키고 로그아웃 합니다.


- **boundedContext/account/service/GymService.java** ( **철현**) 
  - [x]  whenAccountWithdraw() 
    - 탈퇴한 회원이 가지고 있는 이용권을 삭제처리합니다.
    - 이벤트 발생 전에 이용권 시작날짜 전인지 검사하기에 별도 검증 로직을 두진 않았습니다.
- 그 외 부분, 이름 + 연락처 + 주소를 별도 필드로 저장하고 View에서도 참조하지 않게 수정하였습니다.

- **boundedContext/apt/entity/AptAccount.java**
    - [x] Account가 삭제되면 AptAccount의 Account 필드는 null로 저장합니다.

### ETC
❗️ 회원 탈퇴 시❗️
`AptAccount`의 `Account` 속성이 `null`이 되기 때문에 아래의 상황에 놓여있다면
해당 브랜치를 pull 해서 각자 맡은 기능의 코드를 수정해주세요. 💫
- view 에서 Account의 fullName, email, phoneNumber를 참조할 경우
    -> 기록을 남겨두는 history 테이블에 String으로 Account에서 필요한 정보를 미리 저장 후 사용합니다.
- 세대원을 조회할 경우
  -> aptAccountHouse 를 가져올 때 status가 false인 세대원만 가져옵니다.

- **철현** - : PR올린 다른 브랜치와 Gym 충돌 날 것 같아여 머지되면 해결하것습니당

---
Close #78 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->