### PR TITLE
feat : 아파트 정보 등록 시 예외처리 수정

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountService.java
+++ b/src/main/java/com/ll/townforest/boundedContext/apt/service/AptAccountService.java
@@ -45,12 +45,14 @@ public class AptAccountService {
 			return RsData.of("F-2", "거주하시는 동과 호수를 바르게 입력해 주세요.");
 		}
 
-		Optional<AptAccountHouse> householder = aptAccountHouseRepository.findByHouseAndRelationshipAndStatusFalse(
-			house, "본인");
-		if (householder.isPresent()) {
-			return RsData.of("F-3", "세대주가 이미 존재합니다.");
+		if (aptAccountDTO.getRelationship().equals("본인")) {
+			Optional<AptAccountHouse> householder = aptAccountHouseRepository.findByHouseAndRelationshipAndStatusFalse(
+				house, "본인");
+			if (householder.isPresent()) {
+				return RsData.of("F-3", "세대주가 이미 존재합니다.");
+			}
 		}
-
+		
 		return register(account, apt, house, aptAccountDTO.getRelationship());
 	}
 


### PR DESCRIPTION
## Description
아파트 정보 등록 시 예외처리입니다.
<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- **boundedContext/apt/service/AptAccountService.java**
    - [x] canRegister()
        - 아파트 정보 등록에서 세대주가 이미 존재할 때,
          어떤 세대주와의 관계 클릭시에도 "세대주 이미 존재합니다" 알림뜨는 오류 처리했습니다.

