### PR TITLE
refactor : Enum 및 Transactional 도입

### DIFF
--- a/src/main/java/com/ll/townforest/boundedContext/gym/gymEnum/HistoryType.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/gymEnum/HistoryType.java
@@ -1,0 +1,18 @@
+package com.ll.townforest.boundedContext.gym.gymEnum;
+
+import lombok.Getter;
+
+@Getter
+public enum HistoryType {
+	PAYMENT(0),
+	EXTENSION(1),
+	PAUSE(2),
+	RESTART(3),
+	EXPIRATION(4);
+
+	private int status;
+
+	HistoryType(int status) {
+		this.status = status;
+	}
+}

--- a/src/main/java/com/ll/townforest/boundedContext/gym/gymEnum/MembershipType.java
+++ b/src/main/java/com/ll/townforest/boundedContext/gym/gymEnum/MembershipType.java
@@ -1,0 +1,18 @@
+package com.ll.townforest.boundedContext.gym.gymEnum;
+
+import lombok.Getter;
+
+@Getter
+public enum MembershipType {
+	READY(0),
+	STARTING(1),
+	PAUSE(2),
+	EXTENSION(3),
+	RESTART(4);
+
+	private int status;
+
+	MembershipType(int status) {
+		this.status = status;
+	}
+}


### PR DESCRIPTION
## Description
평가때 받은 피드백 사항 일부 반영
<!-- 어떤 기능을 개발했는지 작성합니다. -->

## Changes

- **boundedContext/gym/gymEnum/HistoryType.java** / **gym/gymEnum/MembershipType.java**
    - GymMembership과 History의 status가 약간 달라서 두개의 파일로 구성하였습니다.

- **boundedContext/gym/service/GymService.java**
  - Enum 도입하여 직관적으로 확인할 수 있도록 수정하였습니다.
  - Transactional 어노테이션을 사용하였습니다. 

<!-- "주요 파일"의 변경사항을 작성하고 간단히 로직을 설명합니다. -->

<!-- 예시 
- **account/service/AccountService.java**
  - [ ] join();
    - 가입 가능한 username 및 password인지 확인 후 repository에 저장합니다.
-->

### ETC
멀티 서버가 아니기에 ShedLock을 사용 등 스케줄러 메서드 관련 처리는 수정 하지 않았습니다.
리팩토링 후 메인 브랜치에 바로 적용시킵니다.
<!-- 추가 전달사항을 작성합니다. -->

<!-- 예시
#### 주의사항
- ```username : admin, password : admin``` 사용자는 이미 추가되어 있습니다.
-->

---
Close #108 
<!-- issue 번호를 기입합니다. -->
<!-- 예시 Close #1 -->